### PR TITLE
Upgraded bitcore to version that includes elliptic 1.0.0 and bn.js 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "angular-gravatar": "*",
     "async": "^0.9.0",
-    "bitcore": "git://github.com/bitpay/bitcore.git#0d238f116500a732057ec9dd80a8a87b2190ca49",
+    "bitcore": "git://github.com/bitpay/bitcore.git#e20df2144926dbc20bd468d671e73f8e52bb70c1",
     "blanket": "^1.1.6",
     "browser-pack": "^2.0.1",
     "browserify": "^3.32.1",


### PR DESCRIPTION
- There was bug in squaring that in rare situations would produce an incorrect value, see: https://github.com/indutny/bn.js/commit/3557d780b07ed0ed301e128f326f83c2226fb679
- The incorrect squaring would lead to calculating a bitcoin address where it would be possible to receive funds that would not be spendable.
- For more details about the bug, see: https://github.com/bitpay/bitcore/pull/894
- Fixes issue #2281

Relevant bitcore commit: https://github.com/bitpay/bitcore/commit/e20df2144926dbc20bd468d671e73f8e52bb70c1