### PR TITLE
Important fix: paste into input and textareas

### DIFF
--- a/css/src/mobile.css
+++ b/css/src/mobile.css
@@ -7,7 +7,7 @@
 @media (max-width: 1024px) {
 
   /* disabling text selection */
-  * {
+  body {
     -webkit-user-select: none;
     -khtml-user-select: none;
     -moz-user-select: none;
@@ -163,7 +163,7 @@
   }
 
   .status {
-    bottom: 66px;
+    bottom: 65px;
     left: 0;
   }
 


### PR DESCRIPTION
The previous CSS code disables text selection on all screen but not allowed paste text on input and textareas. This fix enable the copy to inputs and textareas.