### PR TITLE
Fix notification of needing backup on chromeapp

### DIFF
--- a/views/includes/head.html
+++ b/views/includes/head.html
@@ -32,7 +32,7 @@
     <li><a href="#!/profile" title="Profile">
       <i class="icon-person size-18 m10r"></i> {{'My Profile'|translate}}<span class="size-10 text-warning" ng-if="!$root.needsEmailConfirmation && $root.iden.backupNeeded"> [ Needs Backup ]</span></a>
       </li> 
-    <li><a href="#!/" title="Close" ng-click="signout()">
+    <li><a ng-click="signout()">
         <span ng-if="!$root.hasPin"><i class="icon-power size-18 m10r"></i> {{'Close'|translate}}</span>
         <span ng-if="$root.hasPin"><i class="fi-lock size-18 m10r"></i> {{'Lock'|translate}}</span>
       </a></li>


### PR DESCRIPTION
onbeforeunload doesn't work on chrome app, so we removed the attribute href to the signout link.

Fixes #2392 