### PR TITLE
ignorePayPro verification in chrome

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "foundation-icon-fonts": "*",
     "ng-lodash": "~0.2.0",
     "angular-moment": "~0.9.0",
-    "angular-bitcore-wallet-client": "^0.0.16",
+    "angular-bitcore-wallet-client": "^0.0.17",
     "angular-ui-router": "~0.2.13",
     "qrcode-decoder-js": "*",
     "angular-ui-switch": "~0.1.0"

--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('copayApp.controllers').controller('indexController', function($rootScope, $scope, $log, $filter, $timeout, lodash, go, profileService, configService, isCordova, rateService, storageService) {
+angular.module('copayApp.controllers').controller('indexController', function($rootScope, $scope, $log, $filter, $timeout, lodash, go, profileService, configService, isCordova, rateService, storageService, isChromeApp) {
   var self = this;
   self.isCordova = isCordova;
   self.onGoingProcess = {};
@@ -134,7 +134,9 @@ angular.module('copayApp.controllers').controller('indexController', function($r
     $timeout(function() {
       self.setOngoingProcess('updatingPendingTxps', true);
       $log.debug('Updating PendingTxps');
-      fc.getTxProposals({}, function(err, txps) {
+      fc.getTxProposals({
+        ignorePayPro: isChromeApp
+      }, function(err, txps) {
         self.setOngoingProcess('updatingPendingTxps', false);
         if (err) {
           $log.debug('Wallet PendingTxps ERROR:', err);

--- a/src/js/controllers/send.js
+++ b/src/js/controllers/send.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('copayApp.controllers').controller('sendController',
-  function($rootScope, $scope, $window, $timeout, $modal, $filter, $log, notification, isMobile, txStatus, isCordova, bitcore, profileService, configService, rateService) {
+  function($rootScope, $scope, $window, $timeout, $modal, $filter, $log, notification, isMobile, txStatus, isCordova, bitcore, profileService, configService, rateService, isChromeApp) {
     var fc = profileService.focusedClient;
     var self = this;
 
@@ -325,9 +325,8 @@ angular.module('copayApp.controllers').controller('sendController',
     };
 
     this.setFromPayPro = function(uri, form) {
-      var isChromeApp = window.chrome && chrome.runtime && chrome.runtime.id;
       if (isChromeApp) {
-        this.error = 'Payment Protocol not yet supported on ChromeApp';
+        this.error = 'Payment Protocol not supported on Chrome App';
         return;
       }
 

--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -1,7 +1,5 @@
 'use strict';
 
-
-// TODO rateService
 angular.module('copayApp.controllers').controller('walletHomeController', function($scope, $rootScope, $timeout, $filter, $modal, notification, txStatus, isCordova, profileService, lodash) {
 
 

--- a/src/js/services/isChromeApp.js
+++ b/src/js/services/isChromeApp.js
@@ -1,0 +1,4 @@
+'use strict';
+
+angular.module('copayApp.services').value('isChromeApp',  window.chrome && chrome.runtime && chrome.runtime.id);
+


### PR DESCRIPTION
- ignorePayPro verification in chrome, so chrome users can sign PayPros generated from other devices.

