### PR TITLE
When running from browser for first time configCache.wallet is not found

### DIFF
--- a/src/js/services/configService.js
+++ b/src/js/services/configService.js
@@ -57,6 +57,9 @@ angular.module('copayApp.services').factory('configService', function(storageSer
         if (!configCache.bws) {
           configCache.bws = defaultConfig.bws;
         }
+        if (!configCache.wallet) {
+          configCache.wallet = defaultConfig.wallet;
+        }
         if (!configCache.wallet.settings.unitCode) {
           configCache.wallet.settings.unitCode = defaultConfig.wallet.settings.unitCode;
         }


### PR DESCRIPTION
The first time I ran Copay as a server and opened localhost:3000 in Chrome on Mac OSX, the page did not render. The configService had an error, configCache.wallet is undefined, when looking for settings.unitCode. This change solves that error for me.