### PR TITLE
save lang and unit in BWS (for notifications)

### DIFF
--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 angular.module('copayApp.controllers').controller('indexController', function($rootScope, $scope, $log, $filter, $timeout, lodash, go, profileService, configService, isCordova, rateService, storageService, addressService, gettextCatalog, gettext, amMoment) {
-
   var self = this;
   self.isCordova = isCordova;
   self.onGoingProcess = {};
@@ -154,15 +153,50 @@ angular.module('copayApp.controllers').controller('indexController', function($r
   };
 
 
-  self.updatePreferences = function(cb) {
+  self._updateRemotePreferencesFor = function(clients, prefs, cb) {
+    var client = clients.shift();
+
+    if (!client)
+      return cb();
+
+    $log.debug('Saving remote preferences', client.credentials.walletName, prefs);
+    client.savePreferences(prefs, function(err) {
+      if (err) return cb(err);
+
+      self._updateRemotePreferencesFor(clients, prefs, cb);
+    });
+  };
+
+
+  self.updateRemotePreferences = function(opts, cb) {
+    var prefs = opts.preferences || {};
     var fc = profileService.focusedClient;
-    fc.getPreferences(function(err, preferences) {
+
+    //prefs.email  (may come from arguments)
+    prefs.language = self.defaultLanguageIsoCode;
+    prefs.unit = self.unitName;
+
+    var clients = [];
+    if (opts.saveAll) {
+      clients = lodash.values(profileService.walletClients);
+    } else {
+      clients = [fc];
+    };
+
+    self._updateRemotePreferencesFor(clients, prefs, function(err) {
       if (err) {
         self.handleError(err);
         return cb(err);
       }
-      self.preferences = preferences;
-      return cb(err, preferences);
+
+      fc.getPreferences(function(err, preferences) {
+        if (err) {
+          self.handleError(err);
+          return cb(err);
+        }
+        self.preferences = preferences;
+        return cb();
+      });
     });
   };
 
@@ -211,12 +245,15 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 
       $log.debug('Updating Status:', fc, tries);
       get(function(err, walletStatus) {
-        var currentStatusHash = _walletStatusHash(walletStatus); 
-        $log.debug('Status update. hash:' + currentStatusHash + ' Try:'+ tries); 
+        var currentStatusHash = _walletStatusHash(walletStatus);
+        $log.debug('Status update. hash:' + currentStatusHash + ' Try:' + tries);
         if (!err && opts.untilItChanges && initStatusHash == currentStatusHash && tries < 7) {
           return $timeout(function() {
             $log.debug('Retrying update... Try:' + tries)
-            return self.updateAll({walletStatus: null, untilItChanges: true}, initStatusHash, ++tries);
+            return self.updateAll({
+              walletStatus: null,
+              untilItChanges: true
+            }, initStatusHash, ++tries);
           }, 1400 * tries);
         }
         if (!opts.quiet)
@@ -340,7 +377,9 @@ angular.module('copayApp.controllers').controller('indexController', function($r
           return;
         }
         $log.debug('Wallet Opened');
-        self.updateAll(lodash.isObject(walletStatus) ? {walletStatus: walletStatus} : null);
+        self.updateAll(lodash.isObject(walletStatus) ? {
+          walletStatus: walletStatus
+        } : null);
         $rootScope.$apply();
       });
     });
@@ -466,8 +505,8 @@ angular.module('copayApp.controllers').controller('indexController', function($r
     self.alternativeIsoCode = config.alternativeIsoCode;
 
     // Check address
-    addressService.isUsed(self.walletId, balance.byAddress, function(err, used){
-      if (used)  {
+    addressService.isUsed(self.walletId, balance.byAddress, function(err, used) {
+      if (used) {
         $log.debug('Address used. Creating new');
         $rootScope.$emit('Local/NeedNewAddress');
       }
@@ -571,40 +610,27 @@ angular.module('copayApp.controllers').controller('indexController', function($r
     });
   };
 
-  self.setDefaultLanguage = function(setLang) {
-    var userLang;
-    if (!setLang) {
-      userLang = configService.getSync().wallet.settings.defaultLanguage;
-      if (!userLang) {
-        // Auto-detect browser language
-        var androidLang;
+  self.setUxLanguage = function() {
+    var userLang = configService.getSync().wallet.settings.defaultLanguage;
+    if (!userLang) {
+      // Auto-detect browser language
+      var androidLang;
 
-        if (navigator && navigator.userAgent && (androidLang = navigator.userAgent.match(/android.*\W(\w\w)-(\w\w)\W/i))) {
-          userLang = androidLang[1];
-        } else {
-          // works for iOS and Android 4.x
-          userLang = navigator.userLanguage || navigator.language;
-        }
-        userLang = userLang ? (userLang.split('-', 1)[0] || 'en') : 'en';
+      if (navigator && navigator.userAgent && (androidLang = navigator.userAgent.match(/android.*\W(\w\w)-(\w\w)\W/i))) {
+        userLang = androidLang[1];
+      } else {
+        // works for iOS and Android 4.x
+        userLang = navigator.userLanguage || navigator.language;
       }
-      if (userLang != gettextCatalog.getCurrentLanguage()) {
-        $log.debug('Setting default language: ' + userLang);
-        gettextCatalog.setCurrentLanguage(userLang);
-        amMoment.changeLocale(userLang);
-      }
-    } else {
-      configService.set({
-        wallet: {
-          settings: {
-            defaultLanguage: setLang
-          }
-        }
-      }, function() {
-        gettextCatalog.setCurrentLanguage(setLang);
-        amMoment.changeLocale(setLang);
-      });
+      userLang = userLang ? (userLang.split('-', 1)[0] || 'en') : 'en';
     }
-    self.defaultLanguageIsoCode = setLang || userLang;
+    if (userLang != gettextCatalog.getCurrentLanguage()) {
+      $log.debug('Setting default language: ' + userLang);
+      gettextCatalog.setCurrentLanguage(userLang);
+      amMoment.changeLocale(userLang);
+    }
+
+    self.defaultLanguageIsoCode = userLang;
     self.defaultLanguageName = lodash.result(lodash.find(self.availableLanguages, {
       'isoCode': self.defaultLanguageIsoCode
     }), 'name');
@@ -625,14 +651,41 @@ angular.module('copayApp.controllers').controller('indexController', function($r
     });
   });
 
-  $rootScope.$on('Local/UnitSettingUpdated', function(event) {
-    self.updateAll();
-    self.updateTxHistory();
+
+  $rootScope.$on('Local/NewFocusedWallet', function() {
+    self.setUxLanguage();
   });
 
+  $rootScope.$on('Local/LanguageSettingUpdated', function() {
+    self.setUxLanguage();
+    self.updateRemotePreferences({
+      saveAll: true
+    }, function() {
+      $log.debug('Remote preferences saved')
+    });
+  });
 
-  $rootScope.$on('Local/EmailUpdated', function(event, cb) {
-    self.updatePreferences(cb);
+  $rootScope.$on('Local/UnitSettingUpdated', function(event) {
+    // This need to be done first, to update unitName
+    // updateAll do it, but async, later.
+    var config = configService.getSync().wallet.settings;
+    self.unitName = config.unitName;
+
+    self.updateAll();
+    self.updateTxHistory();
+    self.updateRemotePreferences({
+      saveAll: true
+    }, function() {
+      $log.debug('Remote preferences saved')
+    });
+  });
+
+  $rootScope.$on('Local/EmailSettingUpdated', function(event, email, cb) {
+    self.updateRemotePreferences({
+      preferences: {
+        email: email
+      },
+    }, cb);
   });
 
   $rootScope.$on('Local/BWSUpdated', function(event) {
@@ -646,7 +699,9 @@ angular.module('copayApp.controllers').controller('indexController', function($r
   });
 
   self.debouncedUpdate = lodash.throttle(function() {
-    self.updateAll({quiet: true});
+    self.updateAll({
+      quiet: true
+    });
     self.updateTxHistory();
   }, 4000, {
     leading: false,
@@ -708,10 +763,6 @@ angular.module('copayApp.controllers').controller('indexController', function($r
     });
   });
 
-  $rootScope.$on('Local/DefaultLanguage', function(event, setLang) {
-    self.setDefaultLanguage(setLang);
-  });
-
   $rootScope.$on('NewIncomingTx', function() {
     self.updateBalance();
     $timeout(function() {
@@ -720,14 +771,20 @@ angular.module('copayApp.controllers').controller('indexController', function($r
   });
 
   $rootScope.$on('NewOutgoingTx', function() {
-    self.updateAll({walletStatus: null, untilItChanges: true});
+    self.updateAll({
+      walletStatus: null,
+      untilItChanges: true
+    });
   });
 
   lodash.each(['NewTxProposal', 'TxProposalFinallyRejected', 'TxProposalRemoved',
     'Local/NewTxProposal', 'Local/TxProposalAction', 'ScanFinished'
   ], function(eventName) {
     $rootScope.$on(eventName, function(event, untilItChanges) {
-      self.updateAll({walletStatus: null, untilItChanges: untilItChanges});
+      self.updateAll({
+        walletStatus: null,
+        untilItChanges: untilItChanges
+      });
       $timeout(function() {
         self.updateTxHistory();
       }, 3000);
@@ -772,7 +829,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
         storageService.removeCleanAndScanAddresses(function() {});
       }
     });
-    
+
   });
 
   $rootScope.$on('Local/SetTab', function(event, tab, reset) {

--- a/src/js/controllers/preferencesEmail.js
+++ b/src/js/controllers/preferencesEmail.js
@@ -8,20 +8,9 @@ angular.module('copayApp.controllers').controller('preferencesEmailController',
 
       var fc = profileService.focusedClient;
       this.saving = true;
-      fc.savePreferences({
-        email: this.email
-      }, function(err) {
+      $scope.$emit('Local/EmailSettingUpdated', self.email, function() {
         self.saving = false;
-        if (err) {
-          $log.warn(err);
-          $scope.$emit('Local/ClientError', err);
-          return;
-        }
-        $scope.$emit('Local/EmailUpdated', function(err){
-          go.path('preferences');
-        });
+        go.path('preferences');
       });
     };
-
-
   });

--- a/src/js/controllers/preferencesLanguage.js
+++ b/src/js/controllers/preferencesLanguage.js
@@ -1,12 +1,24 @@
 'use strict';
 
 angular.module('copayApp.controllers').controller('preferencesLanguageController',
-  function($scope, $timeout, go) {
+  function($scope, $log, $timeout, configService, go) {
 
     this.save = function(newLang) {
-      $scope.$emit('Local/DefaultLanguage', newLang);
-      $timeout(function() {
-        go.preferences();
-      }, 100);
+
+      var opts = {
+        wallet: {
+          settings: {
+            defaultLanguage: newLang
+          }
+        }
+      };
+
+      configService.set(opts, function(err) {
+        if (err) $log.warn(err);
+        $scope.$emit('Local/LanguageSettingUpdated');
+        $timeout(function() {
+          go.preferences();
+        }, 100);
+      });
     };
   });

--- a/src/js/controllers/preferencesUnit.js
+++ b/src/js/controllers/preferencesUnit.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('copayApp.controllers').controller('preferencesUnitController',
-  function($rootScope, $scope, configService, go) {
+  function($rootScope, $scope, $log, configService, go) {
     var config = configService.getSync();
     this.unitName = config.wallet.settings.unitName;
     this.unitOpts = [
@@ -51,8 +51,9 @@ angular.module('copayApp.controllers').controller('preferencesUnitController',
       this.unitName = newUnit.shortName;
 
       configService.set(opts, function(err) {
-        if (err) console.log(err);
+        if (err) $log.warn(err);
         $scope.$emit('Local/UnitSettingUpdated');
+        go.preferences();
       });
 
     };

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -74,7 +74,7 @@ angular
           'main': {
             templateUrl: 'views/splash.html',
             controller: function($scope, $timeout, $log, profileService, storageService, go) {
-              storageService.getCopayDisclaimer(function(err, val) {
+              storageService.getCopayDisclaimerFlag(function(err, val) {
                 if (!val) go.path('disclaimer');
 
                 if (profileService.profile) {
@@ -109,7 +109,7 @@ angular
           'main': {
             templateUrl: 'views/disclaimer.html',
             controller: function($scope, $timeout, storageService, applicationService, go) {
-              storageService.getCopayDisclaimer(function(err, val) {
+              storageService.getCopayDisclaimerFlag(function(err, val) {
                 $scope.agreed = val;
                 $timeout(function(){
                   $scope.$digest();
@@ -117,7 +117,7 @@ angular
               });
 
               $scope.agree = function() {
-                storageService.setCopayDisclaimer(function(err) {
+                storageService.setCopayDisclaimerFlag(function(err) {
                   $timeout(function(){
                     applicationService.restart();
                   }, 1000);

--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -128,13 +128,16 @@ angular.module('copayApp.services')
         root.setWalletClients();
         storageService.getFocusedWalletId(function(err, focusedWalletId) {
           if (err) return cb(err);
-          root._setFocus(focusedWalletId, cb);
+          root._setFocus(focusedWalletId, function() {
+            $rootScope.$emit('Local/ProfileBound');
+            return cb();
+          });
         });
       });
     };
 
     root.loadAndBindProfile = function(cb) {
-      storageService.getCopayDisclaimer(function(err, val) {
+      storageService.getCopayDisclaimerFlag(function(err, val) {
         if (!val) {
           return cb(new Error('NONAGREEDDISCLAIMER: Non agreed disclaimer'));
         } else {

--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -125,7 +125,6 @@ angular.module('copayApp.services')
         $log.debug('Preferences read');
         if (err) return cb(err);
         root.applyConfig();
-        $rootScope.$emit('Local/DefaultLanguage');
         root.setWalletClients();
         storageService.getFocusedWalletId(function(err, focusedWalletId) {
           if (err) return cb(err);

--- a/src/js/services/storageService.js
+++ b/src/js/services/storageService.js
@@ -184,5 +184,13 @@ angular.module('copayApp.services')
       storage.get('agreeDisclaimer', cb);
     };
 
+    root.setRemotePreferencesStored = function(cb) {
+      storage.set('remotePrefStored', true, cb);
+    };
+
+    root.getRemovePreferencesStored = function(cb) {
+      storage.get('remotePrefStored', cb);
+    };
+
     return root;
   });

--- a/src/js/services/storageService.js
+++ b/src/js/services/storageService.js
@@ -176,19 +176,19 @@ angular.module('copayApp.services')
       storage.remove('config', cb);
     };
 
-    root.setCopayDisclaimer = function(cb) {
+    root.setCopayDisclaimerFlag = function(cb) {
       storage.set('agreeDisclaimer', true, cb);
     };
 
-    root.getCopayDisclaimer = function(cb) {
+    root.getCopayDisclaimerFlag = function(cb) {
       storage.get('agreeDisclaimer', cb);
     };
 
-    root.setRemotePreferencesStored = function(cb) {
+    root.setRemotePrefsStoredFlag = function(cb) {
       storage.set('remotePrefStored', true, cb);
     };
 
-    root.getRemovePreferencesStored = function(cb) {
+    root.getRemotePrefsStoredFlag = function(cb) {
       storage.get('remotePrefStored', cb);
     };
 


### PR DESCRIPTION
Saves `lang` and `unit` setting on BWS for better emails.

This is triggered on changing the language or unit setting, or when setting the email.

On the first 2 cases, all wallet settings will be updated.
When changing the email only the focused wallet will be updated.