### PR TITLE
Fixes open modal for android < 4.3

### DIFF
--- a/src/css/mobile.css
+++ b/src/css/mobile.css
@@ -573,6 +573,7 @@ to prevent collapsing during animation*/
 body.modal-open {
   position: fixed;
   overflow: hidden;
+  z-index: 1;
 }
 
 .reveal-modal {


### PR DESCRIPTION
Opening a modal on Android < 4.3 (that use a native in-app browser, not chrome) doesn't work. This PR fix that.