### PR TITLE
export backup without signing capabilities

### DIFF
--- a/public/views/backup.html
+++ b/public/views/backup.html
@@ -8,7 +8,12 @@
 
 <div class="content p20v" ng-controller="backupController as backup">
   <div class="row m20t">
-    <div class="columns" ng-show="!backup.backupWalletPlainText && !backup.error">
+    <div class="columns" ng-show="!backup.backupWalletPlainText">
+      <div class="text-warning size-14 m10v" ng-show="backup.error">
+        <i class="fi-alert size-12"></i>
+        <span translate> Failed to create backup </span>
+      </div>
+
       <div class="text-warning size-14 m10v" ng-show="backup.isEncrypted">
         <i class="fi-alert size-12"></i>
         <span translate> The private key for this wallet is encrypted. Exporting a backup will keep the private key encrypted in the backup archive.</span>
@@ -28,6 +33,31 @@
         placeholder="{{'Repeat password'|translate}}"
         name="password" ng-model="backup.repeatpassword">
       </div>
+
+
+      <div class="m10t oh" ng-init="hideAdv=true">
+        <a class="button outline light-gray expand tiny" ng-click="hideAdv=!hideAdv">
+          <i class="fi-widget m3r"></i>
+          <span translate ng-hide="!hideAdv">Show Advanced options</span>
+          <span translate ng-hide="hideAdv">Hide Advanced options</span>
+          <i ng-if="hideAdv" class="icon-arrow-down4"></i>
+          <i ng-if="!hideAdv" class="icon-arrow-up4"></i>
+        </a>
+      </div>
+      <div ng-hide="hideAdv" class="row">
+        <div class="large-12 columns">
+          <label for="no-sign" class="line-b oh">
+            <span translate>Do not include private key on backup</span>
+            <switch id="no-sign" name="noSign" ng-model="noSign" class="green right m5t m10b"></switch>
+          </label>
+        </div>
+
+        <div class="m10 size-14 text-gray" translate>
+          A backup without the private key will allow to see wallet balance, transaction, create spend proposals, but will not be able to approve (sign) proposals. 
+
+        </div>
+      </div>
+
 
       <button class="black round expand" ng-click="backup.downloadWalletBackup()"
         ng-disabled="(!backup.password || backup.password != backup.repeatpassword)"
@@ -52,6 +82,9 @@
       </div>
     </div>
   </div>
+
+
+
   <div class="row m20b" ng-show="backup.backupWalletPlainText">
     <div class="large-12 columns">
       <h3 translate>Copy backup to a safe place</h3>

--- a/public/views/modals/txp-details.html
+++ b/public/views/modals/txp-details.html
@@ -102,7 +102,7 @@
         <span translate>Reject</span>
       </button>
     </div>
-    <div class="large-5 medium-5 small-6 columns text-right">
+    <div class="large-5 medium-5 small-6 columns text-right" ng-show="canSign">
       <button class="button primary round expand" ng-click="sign(tx)"
         ng-style="{'background-color':color}"
         ng-disabled="loading">

--- a/public/views/walletHome.html
+++ b/public/views/walletHome.html
@@ -119,6 +119,7 @@
               <div class="size-12 text-gray">
                 <span translate>Multisignature wallet</span> ({{index.m}} <span translate>of</span> {{index.n}})
                 <span ng-if="index.network != 'livenet'">- Testnet</span>
+                <span ng-if="!index.canSign"> - No Private key</span>
               </div>
             </div>
             <div ng-show="!index.isShared">
@@ -127,6 +128,7 @@
               </p>
               <div class="size-12 text-gray" ng-if="index.network != 'livenet'">
                 Testnet
+                <span ng-if="!index.canSign"> - No Private key</span>
               </div>
             </div>
           </div>

--- a/src/js/controllers/backup.js
+++ b/src/js/controllers/backup.js
@@ -11,7 +11,15 @@ angular.module('copayApp.controllers').controller('backupController',
     this.isEncrypted = fc.isPrivKeyEncrypted();
 
     this.downloadWalletBackup = function() {
-      backupService.walletDownload(this.password, function() {
+      var self = this;
+      var opts = {
+        noSign: $scope.noSign,
+      };
+      backupService.walletDownload(this.password, opts, function(err) {
+        if (err) {
+          self.error = true;
+          return ;
+        }
         $rootScope.$emit('Local/BackupDone');
         notification.success(gettext('Backup created'), gettext('Encrypted backup file saved'));
         go.walletHome();
@@ -19,19 +27,32 @@ angular.module('copayApp.controllers').controller('backupController',
     };
 
     this.getBackup = function() {
-      return backupService.walletExport(this.password);
+      var opts = {
+        noSign: $scope.noSign,
+      };
+
+      var ew = backupService.walletExport(this.password, opts);
+      if (!ew) {
+        this.error = true;
+      } else {
+        this.error = false;
+      }
+      return ew;
     };
 
     this.viewWalletBackup = function() {
       var self = this;
       $timeout(function() {
-        self.backupWalletPlainText = self.getBackup();
+        var ew = self.getBackup();
+        if (!ew) return;
+        self.backupWalletPlainText = ew;
         $rootScope.$emit('Local/BackupDone');
       }, 100);
     };
 
     this.copyWalletBackup = function() {
       var ew = this.getBackup();
+      if (!ew) return;
       window.cordova.plugins.clipboard.copy(ew);
       window.plugins.toast.showShortCenter('Copied to clipboard');
       $rootScope.$emit('Local/BackupDone');
@@ -48,6 +69,11 @@ angular.module('copayApp.controllers').controller('backupController',
         name = fc.alias + ' [' + name + ']';
       }
       var ew = this.getBackup();
+      if (!ew) return;
+
+      if( $scope.noSign) 
+        name = name + '(No Private Key)';
+
       var properties = {
         subject: 'Copay Wallet Backup: ' + name,
         body: 'Here is the encrypted backup of the wallet ' + name + ': \n\n' + ew + '\n\n To import this backup, copy all text between {...}, including the symbols {}',

--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -106,6 +106,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
       self.walletName = fc.credentials.walletName;
       self.walletId = fc.credentials.walletId;
       self.isComplete = fc.isComplete();
+      self.canSign = fc.canSign();
       self.txps = [];
       self.copayers = [];
       self.updateColor();

--- a/src/js/services/backupService.js
+++ b/src/js/services/backupService.js
@@ -53,13 +53,14 @@ angular.module('copayApp.services')
       return cb();
     };
 
-    root.walletExport = function(password) {
+    root.walletExport = function(password, opts) {
       if (!password) {
         return null;
       }
       var fc = profileService.focusedClient;
       try {
-        var b = fc.export({});
+        opts = opts || {};
+        var b = fc.export(opts);
         var e = sjcl.encrypt(password, b, {
           iter: 10000
         });
@@ -70,12 +71,13 @@ angular.module('copayApp.services')
       };
     };
 
-    root.walletDownload = function(password, cb) {
+    root.walletDownload = function(password, opts, cb) {
       var fc = profileService.focusedClient;
-      var ew = root.walletExport(password);
+      var ew = root.walletExport(password, opts);
       if (!ew) return cb('Could not create backup');
 
       var walletName = (fc.alias || '') + (fc.alias ? '-' : '') + fc.credentials.walletName;
+      if (opts.noSign) walletName = walletName + '-noSign'
       var filename = walletName + '-Copaybackup.aes.json';
       _download(ew, filename, cb)
     };

--- a/src/js/services/txStatus.js
+++ b/src/js/services/txStatus.js
@@ -7,6 +7,7 @@ angular.module('copayApp.services').factory('txStatus', function($modal, lodash,
     var fc = profileService.focusedClient;
     var status = txp.status;
     var type;
+    var INMEDIATE_SECS = 10;
 
     if (status == 'broadcasted') {
       type = 'broadcasted';
@@ -17,10 +18,15 @@ angular.module('copayApp.services').factory('txStatus', function($modal, lodash,
         copayerId: fc.credentials.copayerId
       });
 
-      if (!action || (action.type == 'accept' && n == 1)) {
+      if (!action)  {
         type = 'created';
       } else if (action.type == 'accept') {
-        type = 'accepted';
+        // created and accepted at the same time?
+        if ( n == 1 && action.createdOn - txp.createdOn < INMEDIATE_SECS ) {
+          type = 'created';
+        } else {
+          type = 'accepted';
+        }
       } else if (action.type == 'reject') {
         type = 'rejected';
       } else {


### PR DESCRIPTION
- this add 'no private key' advanced option to backup.

It is then possible to export a backup without the wallet's private key.

A wallet with a imported backup without private key can: see wallet balance, see tx history, create spend proposal, reject spend proposals, BUT CANNOT SIGN (approve) proposals.