### PR TITLE
Addons can use OngoingProcess indicator

### DIFF
--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -69,6 +69,10 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
     };
   });
 
+  var disableOngoingProcessListener = $rootScope.$on('Addon/OngoingProcess', function(e, name) {
+    self.setOngoingProcess(name);
+  });
+
   $scope.$on('$destroy', function() {
     disableAddrListener();
     disableScannerListener();
@@ -76,6 +80,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
     disableTabListener();
     disableFocusListener();
     disableResumeListener();
+    disableOngoingProcessListener();
     $rootScope.hideMenuBar = false;
   });
 


### PR DESCRIPTION
Make Copay to call ``setOngoingProcess`` when ``Addon/OngoingProcess`` event received.
Addons may emit this event to display relevant process indication to user.
Example: https://github.com/troggy/copay-colored-coins-plugin/blob/41df7c7d90e203e39245e5a574204fd53a884112/js/controllers/assets.js#L11