### PR TITLE
Removes translation for languages name

### DIFF
--- a/public/views/preferencesLanguage.html
+++ b/public/views/preferencesLanguage.html
@@ -11,7 +11,7 @@
   <div ng-show="!prefLang.loading"
     ng-repeat="lang in index.availableLanguages" 
     ng-click="prefLang.save(lang.isoCode)" class="line-b p20 size-14">
-    <span>{{lang.name|translate}}</span>
+    <span>{{lang.name}}</span>
     <i class="fi-check size-16 right" ng-show="index.defaultLanguageIsoCode == lang.isoCode"></i>
   </div>
 </div>

--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -41,28 +41,28 @@ angular.module('copayApp.controllers').controller('indexController', function($r
   self.tab = 'walletHome';
 
   self.availableLanguages = [{
-    name: gettext('English'),
+    name: 'English',
     isoCode: 'en',
   }, {
-    name: gettext('French'),
+    name: 'Français',
     isoCode: 'fr',
   }, {
-    name: gettext('Italian'),
+    name: 'Italiano',
     isoCode: 'it',
   }, {
-    name: gettext('German'),
+    name: 'Deutsch',
     isoCode: 'de',
   }, {
-    name: gettext('Spanish'),
+    name: 'Español',
     isoCode: 'es',
   }, {
-    name: gettext('Portuguese'),
+    name: 'Português',
     isoCode: 'pt',
   }, {
-    name: gettext('Greek'),
+    name: 'Ελληνικά',
     isoCode: 'el',
   }, {
-    name: gettext('Japanese'),
+    name: '日本語',
     isoCode: 'ja',
   }];
 


### PR DESCRIPTION
This PR removes the names of languages in order to use always the name in the original language.