### PR TITLE
Allow addons to customize pending proposals

### DIFF
--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -488,6 +488,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
       if (tx.creatorId != self.copayerId) {
         self.pendingTxProposalsCountForUs = self.pendingTxProposalsCountForUs + 1;
       }
+      addonManager.formatPendingTxp(tx);
     });
     self.txps = txps;
   };

--- a/src/js/services/addonManager.js
+++ b/src/js/services/addonManager.js
@@ -1,28 +1,22 @@
 'use strict';
 
-angular.module('copayApp.services').provider('addonManager', function (lodash) {
+angular.module('copayApp.services').service('addonManager', function (lodash) {
   var addons = [];
 
-  this.registerAddon = function(addonSpec) {
+  this.registerAddon = function (addonSpec) {
     addons.push(addonSpec);
   };
 
-  this.$get = function() {
-    var manager = {};
+  this.addonMenuItems = function () {
+    return lodash.map(addons, function (addonSpec) {
+      return addonSpec.menuItem;
+    });
+  };
 
-    manager.addonMenuItems = function() {
-      return lodash.map(addons, function(addonSpec) {
-        return addonSpec.menuItem;
-      });
-    };
-
-    manager.addonViews = function() {
-      return lodash.map(addons, function(addonSpec) {
-        return addonSpec.view;
-      });
-    };
-
-    return manager;
-  }
+  this.addonViews = function () {
+    return lodash.map(addons, function (addonSpec) {
+      return addonSpec.view;
+    });
+  };
 
 });

--- a/src/js/services/addonManager.js
+++ b/src/js/services/addonManager.js
@@ -1,23 +1,25 @@
 'use strict';
 
-angular.module('copayApp.services').provider('addonManager', function () {
-  var addonMenuItems = [];
-  var addonViews = [];
+angular.module('copayApp.services').provider('addonManager', function (lodash) {
+  var addons = [];
 
   this.registerAddon = function(addonSpec) {
-    addonMenuItems.push(addonSpec.menuItem);
-    addonViews.push(addonSpec.view);
+    addons.push(addonSpec);
   };
 
   this.$get = function() {
     var manager = {};
 
     manager.addonMenuItems = function() {
-      return addonMenuItems;
+      return lodash.map(addons, function(addonSpec) {
+        return addonSpec.menuItem;
+      });
     };
 
     manager.addonViews = function() {
-      return addonViews;
+      return lodash.map(addons, function(addonSpec) {
+        return addonSpec.view;
+      });
     };
 
     return manager;

--- a/src/js/services/addonManager.js
+++ b/src/js/services/addonManager.js
@@ -19,4 +19,12 @@ angular.module('copayApp.services').service('addonManager', function (lodash) {
     });
   };
 
+  this.formatPendingTxp = function (txp) {
+    lodash.each(addons, function (addon) {
+      if (addon.formatPendingTxp) {
+        addon.formatPendingTxp(txp);
+      }
+    });
+  };
+
 });


### PR DESCRIPTION
Addons now may register ``formatPendingTxp`` function which will be called on every pending tx proposal. This allows to add addon-specific information to proposal (e.g. custom amountStr)

Example which adds color information (if any):
https://github.com/troggy/copay-colored-coins-plugin/blob/b56c0f0d2b6f8e8186f712da980b3d33ed91423b/dist/copayColoredCoins.js#L17