### PR TITLE
Handling errors / multiple join / differenciated balance

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,8 +24,8 @@
         <div ng-include="'views/includes/sidebar.html'" ng-if="index.hasProfile"></div>
 
         <div notifications="right top"></div> 
-        <div ng-include="'views/includes/password.html'" ng-if="index.askPassword"
-></div>
+        <div ng-include="'views/includes/password.html'" ng-if="index.askPassword"></div>
+        <div ng-include="'views/includes/alert.html'" ng-if="index.showAlert"></div>
         <div id="sectionContainer">
           <div id="mainSection">
             <section ui-view="main"

--- a/public/views/includes/alert.html
+++ b/public/views/includes/alert.html
@@ -1,0 +1,14 @@
+<div class="passModalMask">
+ </div>
+
+<div class="alertModal">
+  <div class="columns m20t">
+    <div class="m20t  size-14 text-center" translate>
+        <i class="fi-alert"></i>
+        {{index.showAlert.msg|translate}}
+    </div>
+  <div class="text-center m20t" ng-click="index.showAlert.close()">
+      <a class="button outline light-gray round tiny small-4"  translate>OK</a>
+    </div>
+  </div>
+ </div>

--- a/public/views/walletHome.html
+++ b/public/views/walletHome.html
@@ -76,7 +76,7 @@
         <div class="amount" ng-style="{'background-color':index.backgroundColor}">
           <div ng-if="!index.anyOnGoingProcess && !index.notAuthorized">
             <div ng-show="index.updateError" ng-click='index.openWallet(); index.updateTxHistory()'>
-              <span class="size-12 db m10b">{{index.updateError}}</span>
+              <span class="size-12 db m10b">{{index.updateError|translate}}</span>
               <button class="outline white tiny round" translate>Tap to retry</button>
             </div>
 
@@ -481,7 +481,7 @@
         <div class="large-12 columns">
           <div class="oh text-center">
             <span ng-show="index.txHistoryError && !index.notAuthorized" ng-click='index.updateTxHistory()'>
-              <p class="size-12 m10b db text-gray" translate>Could not fetch transaction history</p>
+              <p class="size-12 m10b db text-gray">Could not fetch transaction history</p>
               <button class="outline round light-gray tiny" translate>Tap to retry</button>
             </span>
             <span ng-if="!index.txHistoryError" translate>

--- a/public/views/walletHome.html
+++ b/public/views/walletHome.html
@@ -76,7 +76,7 @@
         <div class="amount" ng-style="{'background-color':index.backgroundColor}">
           <div ng-if="!index.anyOnGoingProcess && !index.notAuthorized">
             <div ng-show="index.updateError" ng-click='index.openWallet(); index.updateTxHistory()'>
-              <span class="size-12 db m10b" translate>Could not update Wallet</span>
+              <span class="size-12 db m10b" translate>{{index.updateError}}</span>
               <button class="outline white tiny round" translate>Tap to retry</button>
             </div>
 

--- a/public/views/walletHome.html
+++ b/public/views/walletHome.html
@@ -481,7 +481,7 @@
         <div class="large-12 columns">
           <div class="oh text-center">
             <span ng-show="index.txHistoryError && !index.notAuthorized" ng-click='index.updateTxHistory()'>
-              <p class="size-12 m10b db text-gray">Could not fetch transaction history</p>
+              <p class="size-12 m10b db text-gray" translate>Could not fetch transaction history</p>
               <button class="outline round light-gray tiny" translate>Tap to retry</button>
             </span>
             <span ng-if="!index.txHistoryError" translate>

--- a/public/views/walletHome.html
+++ b/public/views/walletHome.html
@@ -76,7 +76,7 @@
         <div class="amount" ng-style="{'background-color':index.backgroundColor}">
           <div ng-if="!index.anyOnGoingProcess && !index.notAuthorized">
             <div ng-show="index.updateError" ng-click='index.openWallet(); index.updateTxHistory()'>
-              <span class="size-12 db m10b" translate>{{index.updateError}}</span>
+              <span class="size-12 db m10b">{{index.updateError}}</span>
               <button class="outline white tiny round" translate>Tap to retry</button>
             </div>
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1119,6 +1119,17 @@ input.ng-invalid-match, input.ng-invalid-match:focus {
   padding: 0.6rem 0.8rem !important;
 }
 
+.alertModal {
+  background: #FFFFFF;
+  box-shadow: 0px 0px 6px 0px rgba(0,0,0,0.50);
+  border-radius: 5px;
+  position: absolute;
+  width: 90%;
+  left: 5%;
+  top: 15%;
+  z-index: 1100;
+}
+
 .passModal {
   background: #FFFFFF;
   box-shadow: 0px 0px 6px 0px rgba(0,0,0,0.50);

--- a/src/js/controllers/create.js
+++ b/src/js/controllers/create.js
@@ -63,6 +63,9 @@ angular.module('copayApp.controllers').controller('createController',
           if (err) {
             $log.debug(err);
             self.error = err;
+            $timeout(function() {
+              $rootScope.$apply();
+            });
           }
           else {
             go.walletHome();

--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -960,6 +960,9 @@ angular.module('copayApp.controllers').controller('indexController', function($r
     trailing: true
   });
 
+  self.debouncedUpdateHistory = lodash.throttle(function() {
+    self.updateTxHistory();
+  }, 60000);
 
   $rootScope.$on('Local/Resume', function(event) {
     $log.debug('### Resume event');
@@ -1022,6 +1025,20 @@ angular.module('copayApp.controllers').controller('indexController', function($r
       triggerTxUpdate: true,
     });
   });
+
+
+  $rootScope.$on('NewBlock', function() {
+    if (self.pendingAmount) {
+      self.updateAll();
+    }
+
+    if (self.network =='testnet') {
+      self.debouncedUpdateHistory();
+    } else {
+      self.updateTxHistory();
+    }
+  });
+
 
   $rootScope.$on('NewOutgoingTx', function() {
     self.updateAll({

--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('copayApp.controllers').controller('indexController', function($rootScope, $scope, $log, $filter, $timeout, lodash, go, profileService, configService, isCordova, rateService, storageService, addressService, gettextCatalog, gettext, amMoment, nodeWebkit, addonManager, feeService, isChromeApp) {
+angular.module('copayApp.controllers').controller('indexController', function($rootScope, $scope, $log, $filter, $timeout, lodash, go, profileService, configService, isCordova, rateService, storageService, addressService, gettextCatalog, gettext, amMoment, nodeWebkit, addonManager, feeService, isChromeApp, bwsError) {
   var self = this;
   self.isCordova = isCordova;
   self.onGoingProcess = {};
@@ -243,7 +243,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
         self.updateError = false;
         return fc.getStatus(function(err, ret) {
           if (err) {
-            self.updateError = true;
+            self.updateError = bwsError.msg(err, 'Could not update Wallet');
           } else {
             if (!opts.quiet)
               self.setOngoingProcess('scanning', ret.wallet.scanning);

--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -319,12 +319,12 @@ angular.module('copayApp.controllers').controller('indexController', function($r
   self.setSendMax = function() {
 
     // Set Send max
-    if (self.currentFeeLevel && self.totalBytesToSendMax) { 
+    if (self.currentFeeLevel && self.totalBytesToSendMax) {
       feeService.getCurrentFeeValue(self.currentFeeLevel, function(err, feePerKb) {
 
         // KB to send max
         if (self.totalBytesToSendMax) {
-          var feeToSendMaxSat = parseInt(((self.totalBytesToSendMax * feePerKb ) / 1000.).toFixed(0));
+          var feeToSendMaxSat = parseInt(((self.totalBytesToSendMax * feePerKb) / 1000.).toFixed(0));
           self.availableMaxBalance = strip((self.availableBalanceSat - feeToSendMaxSat) * self.satToUnit);
           self.feeToSendMaxStr = profileService.formatAmount(feeToSendMaxSat) + ' ' + self.unitName;
         } else {
@@ -360,8 +360,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
       fc.getBalance(function(err, balance) {
         self.setOngoingProcess('updatingBalance', false);
         if (err) {
-          $log.debug('Wallet Balance ERROR:', err);
-          $scope.$emit('Local/ClientError', err);
+          self.handleError(err);
           return;
         }
         $log.debug('Wallet Balance:', balance);
@@ -378,8 +377,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
       fc.getTxProposals({}, function(err, txps) {
         self.setOngoingProcess('updatingPendingTxps', false);
         if (err) {
-          $log.debug('Wallet PendingTxps ERROR:', err);
-          $scope.$emit('Local/ClientError', err);
+          self.handleError(err);
         } else {
           $log.debug('Wallet PendingTxps:', txps);
           self.setPendingTxps(txps);
@@ -392,7 +390,6 @@ angular.module('copayApp.controllers').controller('indexController', function($r
   self.updateTxHistory = function(skip) {
     var fc = profileService.focusedClient;
     if (!fc.isComplete()) return;
-
     if (!skip) {
       self.txHistory = [];
     }
@@ -401,6 +398,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
     self.txHistoryError = false;
     self.updatingTxHistory = true;
     self.txHistoryPaging = false;
+
     $timeout(function() {
       fc.getTxHistory({
         skip: self.skipHistory,
@@ -410,8 +408,10 @@ angular.module('copayApp.controllers').controller('indexController', function($r
         if (err) {
           $log.debug('TxHistory ERROR:', err);
           // We do not should errors here, since history is usually
-          // fetched AFTER others requests.
-          //self.handleError(err);
+          // fetched AFTER others requests (if skip=0)
+          if (skip)
+            self.handleError(err);
+
           self.txHistoryError = true;
         } else {
           $log.debug('Wallet Transaction History:', txs);
@@ -423,14 +423,20 @@ angular.module('copayApp.controllers').controller('indexController', function($r
     });
   };
 
+  // This handles errors from BWS/index with are nomally
+  // trigger from async events (like updates)
   self.handleError = function(err) {
     $log.warn('Client ERROR:', err);
     if (err.code === 'NOT_AUTHORIZED') {
-      $scope.$emit('Local/NotAuthorized');
+      self.notAuthorized = true;
+      go.walletHome();
     } else if (err.code === 'NOT_FOUND') {
-      $scope.$emit('Local/BWSNotFound');
+      self.showErrorPopup(gettext('Could not access Wallet Service: Not found'));
     } else {
+      var msg = ""
       $scope.$emit('Local/ClientError', (err.error ? err.error : err));
+      var msg = bwsError.msg(err, gettext('Error at Wallet Service'));
+      self.showErrorPopup(msg);
     }
   };
   self.openWallet = function() {
@@ -478,7 +484,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
       if (tx.outputs.length === 1 && !tx.outputs[0].message) {
         tx.showSingle = true;
         tx.toAddress = tx.outputs[0].toAddress; // txproposal
-        tx.address = tx.outputs[0].address;     // txhistory
+        tx.address = tx.outputs[0].address; // txhistory
       }
     }
   };
@@ -718,7 +724,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
       getHistory(null, function(err, txs) {
         self.setOngoingProcess('generatingCSV', false);
         if (err) {
-          $log.debug('TxHistory ERROR:', err);
+          self.handleError(err);
         } else {
           $log.debug('Wallet Transaction History:', txs);
 
@@ -745,11 +751,11 @@ angular.module('copayApp.controllers').controller('indexController', function($r
               _note += ' Moved:' + (it.amount * satToBtc).toFixed(8)
 
             dataString = formatDate(it.time * 1000) + ',' + formatString(it.addressTo) + ',' + _note + ',' + _amount + ',BTC,,,,';
-            csvContent += dataString + "\n"; 
+            csvContent += dataString + "\n";
 
             if (it.fees && (it.action == 'moved' || it.action == 'sent')) {
               var _fee = (it.fees * satToBtc).toFixed(8)
-               csvContent += formatDate(it.time * 1000) + ',Bitcoin Network Fees,, -' + _fee + ',BTC,,,,' + "\n";
+              csvContent += formatDate(it.time * 1000) + ',Bitcoin Network Fees,, -' + _fee + ',BTC,,,,' + "\n";
             }
           });
 
@@ -768,34 +774,20 @@ angular.module('copayApp.controllers').controller('indexController', function($r
     });
   };
 
-  self.clientError = function(err) {
-    if (isCordova) {
-      navigator.notification.confirm(
-        err,
-        function() {},
-        'Wallet Server Error', ['OK']
-      );
-    } else {
-      if (!isChromeApp) {
-        alert(err);
-      }
-    }
+  self.showErrorPopup = function (msg, cb) {
+    $log.warn('Showing err popup:' + msg);
+    self.showAlert = {
+      msg: msg,
+      close: function(err) {
+        self.showAlert = null;
+        if (cb) return cb(err);
+      },
+    };
+    $timeout(function() {
+      $rootScope.$apply();
+    });
+ 
   };
-
-  self.deviceError = function(err) {
-    if (isCordova) {
-      navigator.notification.confirm(
-        err,
-        function() {},
-        'Device Error', ['OK']
-      );
-    } else {
-      if (!isChromeApp) {
-        alert(err);
-      }
-    }
-  };
-
 
   self.recreate = function(cb) {
     var fc = profileService.focusedClient;
@@ -972,41 +964,12 @@ angular.module('copayApp.controllers').controller('indexController', function($r
   $rootScope.$on('Local/BackupDone', function(event) {
     self.needsBackup = false;
     storageService.setBackupFlag(self.walletId, function(err) {
-      if (err) $rootScope.$emit('Local/DeviceError', err)
+      if (err) root.showErrorPopup(err);
     });
   });
 
-  $rootScope.$on('Local/NotAuthorized', function(event) {
-    self.notAuthorized = true;
-    $rootScope.$apply();
-  });
-
-  $rootScope.$on('Local/BWSNotFound', function(event) {
-    self.clientError('Could not access Wallet Service: Not found');
-    $rootScope.$apply();
-  });
-
   $rootScope.$on('Local/DeviceError', function(event, err) {
-    self.deviceError(err);
-    $rootScope.$apply();
-  });
-
-  $rootScope.$on('Local/ClientError', function(event, err) {
-    if (err.code && err.code === 'NOT_AUTHORIZED') {
-      // Show not error, just redirect to home (where the recreate option is shown)
-      go.walletHome();
-    } else if (err && err.cors == 'rejected') {
-      $log.debug('CORS error:', err);
-    } else if (err.code === 'ETIMEDOUT' || err.code === 'CONNECTION_ERROR') {
-      $log.debug('Time out:', err);
-    } else {
-      var msg = 'Error at Wallet Service: ';
-      if (err.message) msg = msg + err.message;
-      else if (err.error) msg = msg + err.error;
-      else msg = msg + (lodash.isObject(err) ? JSON.stringify(err) : err);
-      self.clientError(msg);
-    }
-    $rootScope.$apply();
+    root.showErrorPopup(err);
   });
 
   $rootScope.$on('Local/WalletImported', function(event, walletId) {
@@ -1032,7 +995,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
       self.updateAll();
     }
 
-    if (self.network =='testnet') {
+    if (self.network == 'testnet') {
       self.debouncedUpdateHistory();
     } else {
       self.updateTxHistory();
@@ -1103,6 +1066,10 @@ angular.module('copayApp.controllers').controller('indexController', function($r
 
   $rootScope.$on('Local/SetTab', function(event, tab, reset) {
     self.setTab(tab, reset);
+  });
+
+  $rootScope.$on('Local/ShowAlert', function(event, msg, cb) {
+    self.showErrorPopup(msg,cb);
   });
 
   $rootScope.$on('Local/NeedsPassword', function(event, isSetup, cb) {

--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -243,7 +243,7 @@ angular.module('copayApp.controllers').controller('indexController', function($r
         self.updateError = false;
         return fc.getStatus(function(err, ret) {
           if (err) {
-            self.updateError = bwsError.msg(err, 'Could not update Wallet');
+            self.updateError = bwsError.msg(err, gettext('Could not update Wallet'));
           } else {
             if (!opts.quiet)
               self.setOngoingProcess('scanning', ret.wallet.scanning);

--- a/src/js/controllers/join.js
+++ b/src/js/controllers/join.js
@@ -153,7 +153,7 @@ angular.module('copayApp.controllers').controller('joinController',
         }, function(err) {
           if (err) {
             self.loading = false;
-            self.error = gettext('Could not join wallet: ') +  (err.message ? err.message : err);
+            self.error = err;
             $rootScope.$apply();
             return
           }

--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -175,7 +175,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
       $scope.alternativeAmountStr = tx.alternativeAmountStr;
       $scope.copayers = copayers
       $scope.copayerId = fc.credentials.copayerId;
-      $scope.canSign= fc.canSign();
+      $scope.canSign = fc.canSign();
       $scope.loading = null;
       $scope.color = fc.backgroundColor;
       refreshUntilItChanges = false;
@@ -259,7 +259,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
                   self.setOngoingProcess();
                   $scope.loading = false;
                   if (err) {
-                    $scope.error = bwsError.msg('Could not broadcast payment');
+                    $scope.error = bwsError.msg(err, gettext('Could not broadcast payment'));
                     $scope.$digest();
                   } else {
                     $log.debug('Transaction signed and broadcasted')
@@ -288,7 +288,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
             self.setOngoingProcess();
             $scope.loading = false;
             if (err) {
-              $scope.error = bwsError.msg(err,gettext('Could not reject payment'));
+              $scope.error = bwsError.msg(err, gettext('Could not reject payment'));
               $scope.$digest();
             } else {
               $modalInstance.close(txpr);
@@ -327,7 +327,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
             self.setOngoingProcess();
             $scope.loading = false;
             if (err) {
-              $scope.error = bwsError.msg(gettext('Could not broadcast payment'));
+              $scope.error = bwsError.msg(err, gettext('Could not broadcast payment'));
               $scope.$digest();
             } else {
 
@@ -397,9 +397,9 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
       addressService.getAddress(fc.credentials.walletId, forceNew, function(err, addr) {
         self.generatingAddress = false;
 
-        if (err)  {
+        if (err) {
           self.addrError = err;
-        }  else {
+        } else {
           if (addr)
             self.addr[fc.credentials.walletId] = addr;
         }
@@ -657,7 +657,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
     var prefix =
       fc.credentials.m > 1 ? gettext('Could not create payment proposal') : gettext('Could not send payment');
 
-    this.error = bwsError.msg(err, prefix); 
+    this.error = bwsError.msg(err, prefix);
 
     $timeout(function() {
       $scope.$digest();
@@ -691,7 +691,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
   this.submitForm = function() {
     var fc = profileService.focusedClient;
     var unitToSat = this.unitToSatoshi;
-    
+
     if (isCordova && this.isWindowsPhoneApp) {
       this.hideAddress = false;
       this.hideAmount = false;
@@ -722,7 +722,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
 
       feeService.getCurrentFeeValue(self.currentSendFeeLevel, function(err, feePerKb) {
         if (err) $log.debug(err);
-console.log('[walletHome.js.757:amount:]',amount, feePerKb); //TODO
+        console.log('[walletHome.js.757:amount:]', amount, feePerKb); //TODO
         fc.sendTxProposal({
           toAddress: address,
           amount: amount,
@@ -1046,7 +1046,7 @@ console.log('[walletHome.js.757:amount:]',amount, feePerKb); //TODO
   };
 
   this.confirmDialog = function(msg, cb) {
-    if (isCordova) { 
+    if (isCordova) {
       navigator.notification.confirm(
         msg,
         function(buttonIndex) {
@@ -1074,11 +1074,11 @@ console.log('[walletHome.js.757:amount:]',amount, feePerKb); //TODO
       fee: feeStr
     });
 
-    this.confirmDialog(msg, function(confirmed){
-      if (confirmed) 
+    this.confirmDialog(msg, function(confirmed) {
+      if (confirmed)
         self._doSendAll(amount);
     });
-  }; 
+  };
 
   /* Start setup */
 

--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('copayApp.controllers').controller('walletHomeController', function($scope, $rootScope, $timeout, $filter, $modal, $log, notification, txStatus, isCordova, profileService, lodash, configService, rateService, storageService, bitcore, isChromeApp, gettext, gettextCatalog, nodeWebkit, addressService, feeService) {
+angular.module('copayApp.controllers').controller('walletHomeController', function($scope, $rootScope, $timeout, $filter, $modal, $log, notification, txStatus, isCordova, profileService, lodash, configService, rateService, storageService, bitcore, isChromeApp, gettext, gettextCatalog, nodeWebkit, addressService, feeService, bwsError) {
 
   var self = this;
   $rootScope.hideMenuBar = false;
@@ -94,24 +94,6 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
   var cancel_msg = gettextCatalog.getString('Cancel');
   var confirm_msg = gettextCatalog.getString('Confirm');
 
-  // walletHome
-
-
-  var parseError = function(err) {
-    if (!err) return;
-
-    if (err.message) {
-      // TODO : this is not used anymore?
-      if (err.message.indexOf('CORS') >= 0) {
-        err.message = gettext('Could not connect wallet service. Check your Internet connection and your wallet service configuration.');
-      }
-
-      if (err.message.indexOf('TIMEDOUT') >= 0) {
-        err.message = gettext('Wallet service timed out. Check your Internet connection and your wallet service configuration.');
-      }
-    }
-  };
-
   $scope.openCopayersModal = function(copayers, copayerId) {
     var fc = profileService.focusedClient;
 
@@ -152,13 +134,14 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
         });
         addressService.getAddress(walletId, false, function(err, addr) {
           $scope.gettingAddress = false;
-          if (!err || addr)
-            $modalInstance.close(addr);
-          else {
-            parseError(err);
+
+          if (err) {
             self.error = err;
             $modalInstance.dismiss('cancel');
+            return;
           }
+
+          $modalInstance.close(addr);
         });
       };
     };
@@ -247,8 +230,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
         if (fc.isPrivKeyEncrypted()) {
           profileService.unlockFC(function(err) {
             if (err) {
-              parseError(err);
-              $scope.error = err;
+              $scope.error = bwsError.msg(err);
               return;
             }
             return $scope.sign(txp);
@@ -265,8 +247,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
             self.setOngoingProcess();
             if (err) {
               $scope.loading = false;
-              parseError(err);
-              $scope.error = err.message || gettext('Could not accept payment. Check your Internet connection and try again');
+              $scope.error = bwsError.msg(err, gettext('Could not accept payment'));
               $scope.$digest();
             } else {
               //if txp has required signatures then broadcast it
@@ -278,8 +259,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
                   self.setOngoingProcess();
                   $scope.loading = false;
                   if (err) {
-                    parseError(err);
-                    $scope.error = gettext('Could not broadcast payment. Check your Internet connection and try again');
+                    $scope.error = bwsError.msg('Could not broadcast payment');
                     $scope.$digest();
                   } else {
                     $log.debug('Transaction signed and broadcasted')
@@ -308,8 +288,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
             self.setOngoingProcess();
             $scope.loading = false;
             if (err) {
-              parseError(err);
-              $scope.error = err.message || gettext('Could not reject payment. Check your Internet connection and try again');
+              $scope.error = bwsError.msg(err,gettext('Could not reject payment'));
               $scope.$digest();
             } else {
               $modalInstance.close(txpr);
@@ -330,8 +309,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
 
             // Hacky: request tries to parse an empty response
             if (err && !(err.message && err.message.match(/Unexpected/))) {
-              parseError(err);
-              $scope.error = err.message || gettext('Could not delete payment proposal. Check your Internet connection and try again');
+              $scope.error = bwsError.msg(err, gettext('Could not delete payment proposal'));
               $scope.$digest();
               return;
             }
@@ -349,8 +327,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
             self.setOngoingProcess();
             $scope.loading = false;
             if (err) {
-              parseError(err);
-              $scope.error = err.message || gettext('Could not broadcast payment. Check your Internet connection and try again');
+              $scope.error = bwsError.msg(gettext('Could not broadcast payment'));
               $scope.$digest();
             } else {
 
@@ -420,13 +397,12 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
       addressService.getAddress(fc.credentials.walletId, forceNew, function(err, addr) {
         self.generatingAddress = false;
 
-        if (err) {
-          parseError(err);
-          self.addrError = err.message || gettext('Could not create address. Check your Internet connection and try again');
+        if (err)  {
+          self.addrError = err;
+        }  else {
+          if (addr)
+            self.addr[fc.credentials.walletId] = addr;
         }
-
-        if (addr)
-          self.addr[fc.credentials.walletId] = addr;
 
         $scope.$digest();
       });
@@ -678,16 +654,10 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
 
   this.setSendError = function(err) {
     var fc = profileService.focusedClient;
-    $log.warn(err);
-    parseError(err);
-    var errMessage =
+    var prefix =
       fc.credentials.m > 1 ? gettext('Could not create payment proposal') : gettext('Could not send payment');
 
-    //This are abnormal situations, but still err message will not be translated
-    //(the should) we should switch using err.code and use proper gettext messages
-    errMessage = errMessage + '. ' + (err.message ? err.message : gettext('Check your Internet connection and try again'));
-
-    this.error = errMessage;
+    this.error = bwsError.msg(err, prefix); 
 
     $timeout(function() {
       $scope.$digest();
@@ -802,8 +772,7 @@ console.log('[walletHome.js.757:amount:]',amount, feePerKb); //TODO
       profileService.lockFC();
       self.setOngoingProcess();
       if (err) {
-        $log.debug('Sign error:', err);
-        err.message = gettext('The payment was created but could not be signed. Please try again from home screen.') + (err.message ? ' ' + err.message : '');
+        err.message = bwsError.msg(err, gettext('The payment was created but could not be signed. Please try again from home screen'));
         return cb(err);
       }
 
@@ -812,7 +781,7 @@ console.log('[walletHome.js.757:amount:]',amount, feePerKb); //TODO
         fc.broadcastTxProposal(signedTx, function(err, btx, memo) {
           self.setOngoingProcess();
           if (err) {
-            err.message = gettext('The payment was signed but could not be broadcasted. Please try again from home screen.') + (err.message ? ' ' + err.message : '');
+            err.message = bwsError.msg(err, gettext('The payment was signed but could not be broadcasted. Please try again from home screen'));
             return cb(err);
           }
           if (memo)

--- a/src/js/services/addressService.js
+++ b/src/js/services/addressService.js
@@ -1,7 +1,7 @@
 'use strict';
 'use strict';
 angular.module('copayApp.services')
-  .factory('addressService', function(storageService, profileService, $log, $timeout, lodash) {
+  .factory('addressService', function(storageService, profileService, $log, $timeout, lodash, bwsError, gettext) {
     var root = {};
 
 
@@ -34,8 +34,7 @@ angular.module('copayApp.services')
               root._createAddress(walletId, cb);
             }, 5000);
           }
-          $log.debug('Creating address ERROR:', err);
-          return cb(err);
+          return bwsError.cb(err, gettext('Could not create address'), cb);
         }
         return cb(null, addr.address);
       });

--- a/src/js/services/bwsError.js
+++ b/src/js/services/bwsError.js
@@ -12,103 +12,78 @@ angular.module('copayApp.services')
           case 'CONNECTION_ERROR':
             body = gettext('Network connection error');
             break;
-            ;;
           case 'NOT_FOUND':
             body = gettext('Wallet service not found');
             break;
-            ;;
           case 'BAD_SIGNATURES': 
             body = gettext('Signatures rejected by server');
             break;
-            ;;
           case 'COPAYER_DATA_MISMATCH': 
             body = gettext('Copayer data mismatch');
             break;
-            ;;
           case 'COPAYER_IN_WALLET': 
             body = gettext('Copayer already in this wallet');
             break;
-            ;;
           case 'COPAYER_REGISTERED': 
             body = gettext('Copayer already registered');
             break;
-            ;;
           case 'COPAYER_VOTED': 
             body = gettext('Copayer already voted on this spend proposal');
             break;
-            ;;
           case 'DUST_AMOUNT': 
             body = gettext('Amount  below dust threshold');
             break;
-            ;;
           case 'INCORRECT_ADDRESS_NETWORK': 
             body = gettext('Incorrect address network');
             break;
-            ;;
           case 'INSUFFICIENT_FUNDS': 
             body = gettext('Insufficient funds');
             break;
-            ;;
           case 'INSUFFICIENT_FUNDS_FOR_FEE': 
             body = gettext('Insufficient funds for fee');
             break;
-            ;;
           case 'INVALID_ADDRESS': 
             body = gettext('Invalid address');
             break;
-            ;;
           case 'LOCKED_FUNDS': 
             body = gettext('Funds are locked by pending spend proposals');
             break;
-            ;;
           case 'NOT_AUTHORIZED': 
             body = gettext('Not authorized');
             break;
-            ;;
           case 'TX_ALREADY_BROADCASTED': 
             body = gettext('Transaction already broadcasted');
             break;
-            ;;
           case 'TX_CANNOT_CREATE': 
             body = gettext('Locktime in effect. Please wait to create a new spend proposal');
             break;
-            ;;
           case 'TX_CANNOT_REMOVE': 
             body = gettext('Locktime in effect. Please wait to remove this spend proposal');
             break;
-            ;;
           case 'TX_NOT_ACCEPTED': 
             body = gettext('Spend proposal is not accepted');
             break;
-            ;;
           case 'TX_NOT_FOUND': 
             body = gettext('Spend proposal not found');
             break;
-            ;;
           case 'TX_NOT_PENDING': 
             body = gettext('The spend proposal is not pending');
             break;
-            ;;
           case 'UPGRADE_NEEDED': 
             body = gettext('Please upgrade Copay to perform this action');
             break;
-            ;;
           case 'WALLET_ALREADY_EXISTS': 
             body = gettext('Wallet already exists');
             break;
-            ;;
           case 'WALLET_FULL': 
             body = gettext('Wallet is full');
             break;
-            ;;
           case 'WALLET_NOT_COMPLETE': 
             body = gettext('Wallet is not complete');
             break;
-            ;;
           case 'WALLET_NOT_FOUND': 
             body = gettext('Wallet not found');
             break;
-            ;;
         }
       }
 

--- a/src/js/services/bwsError.js
+++ b/src/js/services/bwsError.js
@@ -1,0 +1,125 @@
+'use strict';
+angular.module('copayApp.services')
+  .factory('bwsError', function bwcErrorService($log, gettext) {
+    var root = {};
+   
+   root.msg = function(err, prefix) {
+      var body = '';
+      prefix = prefix || '';
+
+      if  (err && err.code)  {
+        switch(err.code) {
+          case 'CONNECTION_ERROR':
+            body = gettext('Network connection error');
+            break;
+            ;;
+          case 'NOT_FOUND':
+            body = gettext('Wallet service not found');
+            break;
+            ;;
+          case 'BAD_SIGNATURES': 
+            body = gettext('Signatures rejected by server');
+            break;
+            ;;
+          case 'COPAYER_DATA_MISMATCH': 
+            body = gettext('Copayer data mismatch');
+            break;
+            ;;
+          case 'COPAYER_IN_WALLET': 
+            body = gettext('Copayer already in this wallet');
+            break;
+            ;;
+          case 'COPAYER_REGISTERED': 
+            body = gettext('Copayer already registered');
+            break;
+            ;;
+          case 'COPAYER_VOTED': 
+            body = gettext('Copayer already voted on this spend proposal');
+            break;
+            ;;
+          case 'DUST_AMOUNT': 
+            body = gettext('Amount  below dust threshold');
+            break;
+            ;;
+          case 'INCORRECT_ADDRESS_NETWORK': 
+            body = gettext('Incorrect address network');
+            break;
+            ;;
+          case 'INSUFFICIENT_FUNDS': 
+            body = gettext('Insufficient funds');
+            break;
+            ;;
+          case 'INSUFFICIENT_FUNDS_FOR_FEE': 
+            body = gettext('Insufficient funds for fee');
+            break;
+            ;;
+          case 'INVALID_ADDRESS': 
+            body = gettext('Invalid address');
+            break;
+            ;;
+          case 'LOCKED_FUNDS': 
+            body = gettext('Funds are locked by pending spend proposals');
+            break;
+            ;;
+          case 'NOT_AUTHORIZED': 
+            body = gettext('Not authorized');
+            break;
+            ;;
+          case 'TX_ALREADY_BROADCASTED': 
+            body = gettext('Transaction already broadcasted');
+            break;
+            ;;
+          case 'TX_CANNOT_CREATE': 
+            body = gettext('Locktime in effect. Please wait to create a new spend proposal');
+            break;
+            ;;
+          case 'TX_CANNOT_REMOVE': 
+            body = gettext('Locktime in effect. Please wait to remove this spend proposal');
+            break;
+            ;;
+          case 'TX_NOT_ACCEPTED': 
+            body = gettext('Spend proposal is not accepted');
+            break;
+            ;;
+          case 'TX_NOT_FOUND': 
+            body = gettext('Spend proposal not found');
+            break;
+            ;;
+          case 'TX_NOT_PENDING': 
+            body = gettext('The spend proposal is not pending');
+            break;
+            ;;
+          case 'UPGRADE_NEEDED': 
+            body = gettext('Please upgrade Copay to perform this action');
+            break;
+            ;;
+          case 'WALLET_ALREADY_EXISTS': 
+            body = gettext('Wallet already exists');
+            break;
+            ;;
+          case 'WALLET_FULL': 
+            body = gettext('Wallet is full');
+            break;
+            ;;
+          case 'WALLET_NOT_COMPLETE': 
+            body = gettext('Wallet is not complete');
+            break;
+            ;;
+          case 'WALLET_NOT_FOUND': 
+            body = gettext('Wallet not found');
+            break;
+            ;;
+        }
+      }
+
+      var msg = prefix + ( body ? ': ' + body  : '');
+      $log.warn("BWC ERROR:" +  msg);
+      return msg;
+    };
+
+    root.cb = function (err,prefix, cb) {
+      return cb(root.msg(err, prefix))
+    };
+
+    return root;
+  });

--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -224,9 +224,13 @@ angular.module('copayApp.services')
 
       try {
         var walletData = this.getUtils().fromSecret(opts.secret);
-        if (root.walletClients[walletData.walletId])
-          return cb(gettext('Cannot join the same wallet more that once'));
 
+        // check if exist
+        if (lodash.find(root.profile.credentials, {
+          'walletId': walletData.walletId
+        })) {
+            return cb(gettext('Cannot join the same wallet more that once'));
+        }
       } catch (ex) {
         return cb(gettext('Bad wallet invitation'));
       }

--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -12,6 +12,21 @@ angular.module('copayApp.services')
       return bwcService.getUtils();
     };
 
+    root.errorCb = function(err, prefix, cb) {
+      var body = '';
+
+      prefix = gettext(prefix);
+      if  (!err || !err.code) return cb(prefix);
+
+      switch(err.code) {
+        case 'CONNECTION_ERROR':
+          body = gettext('Network connection error');
+          ;;
+      }
+
+      return cb(prefix + ( body ? ': ' + body  : ''));
+    };
+
     root.formatAmount = function(amount) {
       var config = configService.getSync().wallet.settings;
       if (config.unitCode == 'sat') return amount;
@@ -176,7 +191,7 @@ angular.module('copayApp.services')
       walletClient.createWallet('Personal Wallet', 'me', 1, 1, {
         network: 'livenet'
       }, function(err) {
-        if (err) return cb(gettext('Error creating wallet. Check your internet connection'));
+        if (err) return root.errorCb(err, 'Error creating wallet', cb);
         var p = Profile.create({
           credentials: [JSON.parse(walletClient.export())],
         });
@@ -198,7 +213,7 @@ angular.module('copayApp.services')
       walletClient.createWallet(opts.name, opts.myName || 'me', opts.m, opts.n, {
         network: opts.networkName
       }, function(err, secret) {
-        if (err) return cb(gettext('Error creating wallet'));
+        if (err) return root.errorCb(err, 'Error creating wallet', cb);
 
         root.profile.credentials.push(JSON.parse(walletClient.export()));
         root.setWalletClients();


### PR DESCRIPTION
- fixes https://github.com/bitpay/copay/issues/2812
- Better error handling for error coming from BWC/BWS (matching new BWS's error codes)
- Handles and upgrades with the new 'newBlock' notification (when using the new `useUnconfirmedSpend` flag)
- Displays balance differentiated for confirmed/unconfirmed  (when using the new `useUnconfirmedSpend` flag)
- add a universal error popup (to replace alert() that does not work on ChromeApp)