### PR TITLE
Allow addon menu items to run arbitrary code on click

### DIFF
--- a/public/views/includes/menu-item.html
+++ b/public/views/includes/menu-item.html
@@ -1,4 +1,4 @@
-<a  ng-click="index.setTab(item.link)" ng-class="{'active': index.tab == item.link}" id="menu-{{item.link}}">
+<a  ng-click="index.setTab(item, false, 0, true)" ng-class="{'active': index.tab == item.link}" id="menu-{{item.link}}">
     <i class="size-24 {{item.icon}} db"></i>
     <div class="size-10 tu">
         {{ item.title|translate }}

--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('copayApp.controllers').controller('indexController', function($rootScope, $scope, $log, $filter, $timeout, lodash, go, profileService, configService, isCordova, rateService, storageService, addressService, gettextCatalog, gettext, amMoment, nodeWebkit, addonManager, feeService, isChromeApp, bwsError, txFormatService, glideraService) {
+angular.module('copayApp.controllers').controller('indexController', function($rootScope, $scope, $log, $filter, $timeout, lodash, go, profileService, configService, isCordova, rateService, storageService, addressService, gettextCatalog, gettext, amMoment, nodeWebkit, addonManager, feeService, isChromeApp, bwsError, txFormatService, glideraService, $state) {
   var self = this;
   self.isCordova = isCordova;
   self.onGoingProcess = {};
@@ -150,39 +150,62 @@ angular.module('copayApp.controllers').controller('indexController', function($r
     });
   };
 
-  self.setTab = function(tab, reset, tries) {
+  self.setTab = function(tab, reset, tries, switchState) {
     tries = tries || 0;
 
+    // check if the whole menu item passed
+    if (typeof tab == 'object') {
+      if (tab.open) {
+        if (tab.link) {
+          self.tab = tab.link;
+        }
+        tab.open();
+        return;
+      } else {
+        return self.setTab(tab.link, reset, tries, switchState);
+      }
+    }
     if (self.tab === tab && !reset)
       return;
 
     if (!document.getElementById('menu-' + tab) && ++tries < 5) {
       return $timeout(function() {
-        self.setTab(tab, reset, tries);
+        self.setTab(tab, reset, tries, switchState);
       }, 300);
     }
 
-    if (!self.tab)
+    if (!self.tab || !$state.is('walletHome'))
       self.tab = 'walletHome';
 
-    if (document.getElementById(self.tab)) {
-      document.getElementById(self.tab).className = 'tab-out tab-view ' + self.tab;
-      var old = document.getElementById('menu-' + self.tab);
-      if (old) {
-        old.className = '';
+    var changeTab = function() {
+      if (document.getElementById(self.tab)) {
+        document.getElementById(self.tab).className = 'tab-out tab-view ' + self.tab;
+        var old = document.getElementById('menu-' + self.tab);
+        if (old) {
+          old.className = '';
+        }
       }
+
+      if (document.getElementById(tab)) {
+        document.getElementById(tab).className = 'tab-in  tab-view ' + tab;
+        var newe = document.getElementById('menu-' + tab);
+        if (newe) {
+          newe.className = 'active';
+        }
+      }
+
+      self.tab = tab;
+      $rootScope.$emit('Local/TabChanged', tab);
+    };
+
+    if (switchState && !$state.is('walletHome')) {
+      go.path('walletHome', function() {
+        changeTab();
+      });
+      return;
     }
 
-    if (document.getElementById(tab)) {
-      document.getElementById(tab).className = 'tab-in  tab-view ' + tab;
-      var newe = document.getElementById('menu-' + tab);
-      if (newe) {
-        newe.className = 'active';
-      }
-    }
-
-    self.tab = tab;
-    $rootScope.$emit('Local/TabChanged', tab);
+    changeTab();
   };
 
 


### PR DESCRIPTION
Another iteration of [this](https://github.com/bitpay/copay/pull/3069) PR
Now addresses this issue: https://github.com/bitpay/copay/pull/3069#issuecomment-138290326

Function ``setTab`` now accepts optional flag specifying whether to switch to ``walletHome`` state or not. This flag is set only for click handlers in bottom menu. This is not the proper fix, but rather a workaround. Proper fix would be to prevent ``setTab`` calling for states different from ``walletHome``