### PR TITLE
fix Japanese phrase spacing for non ja language

### DIFF
--- a/public/views/backup.html
+++ b/public/views/backup.html
@@ -75,7 +75,7 @@
     <div class="row" ng-show="show">
         <div class="columns">
         <div class="p10 enable_text_select" style="background:#eee">
-          <span ng-repeat="word in wordsC.mnemonicWords"><span style="white-space:nowrap">{{word}}</span><span ng-show="index.defaultLanguageIsoCode == 'ja'">&#x3000;</span> </span>  
+          <span ng-repeat="word in wordsC.mnemonicWords"><span style="white-space:nowrap">{{word}}</span><span ng-show="word.match(/[\u3041-\u308f]/)!=null">&#x3000;</span> </span>  
         </div>
         </div>
     </div>


### PR DESCRIPTION
This fixes the following bug:

1. Generate wallet in Japanese setting.
2. Switch device language to English.
3. view phrase for wallet
4. notice the ideographic space is missing. (words look very close together)

the [\u3041-\u308f] block was taken from here:
https://en.wikipedia.org/wiki/Hiragana_(Unicode_block)

All words in the list contain at least one of the characters in the block I set, and also, other languages should not have Japanese in them I think :-P