### PR TITLE
[WIP] Custom Flat Fees.

### DIFF
--- a/public/views/walletHome.html
+++ b/public/views/walletHome.html
@@ -403,7 +403,10 @@
                       ng-click="home.setFee(fee.level)" class="line-b p20">
                       {{index.feeOpts[fee.level]|translate}}
                       <i class="fi-check size-16 right"
-                        ng-show="(home.currentSendFeeLevel || index.currentFeeLevel) == fee.level"></i>
+                        ng-show="(home.currentSendFeeLevel || index.currentFeeLevel) == fee.level && fee.level != index.feeOpts['custom']"></i>
+                      <div class="input right" ng-show="(home.currentSendFeeLevel || index.currentFeeLevel) == fee.level && fee.level == index.feeOpts['custom']">
+                        <input type="number" id="customFee" ng-disabled="home.blockUx" name="customFee" ng-attr-placeholder="{{'Satoshis'|translate}}" ng-minlength="10000" ng-maxlength="10000000" ng-model="_customFee" valid-amount required autocomplete="off" ng-focus="home.formFocus('customFee')" ng-blur="home.formFocus(false)">
+                      </div>
                     </li>
                   </ul>
                 </div>

--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -680,6 +680,19 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
         configurable: true
       });
 
+    Object.defineProperty($scope,
+      "_customFee", {
+        get: function() {
+          return $scope.__customFee;
+        },
+        set: function(newValue) {
+          $scope.__customFee = newValue;
+          self.resetError();
+        },
+        enumerable: true,
+        configurable: true
+      });
+
     var fc = profileService.focusedClient;
     // ToDo: use a credential's (or fc's) function for this
     this.hideNote = !fc.credentials.sharedEncryptingKey;

--- a/src/js/services/feeService.js
+++ b/src/js/services/feeService.js
@@ -7,7 +7,8 @@ angular.module('copayApp.services').factory('feeService', function($log, profile
   root.feeOpts = {
     priority: gettextCatalog.getString('Priority'),
     normal: gettextCatalog.getString('Normal'),
-    economy: gettextCatalog.getString('Economy')
+    economy: gettextCatalog.getString('Economy'),
+    custom: gettextCatalog.getString('Custom')
   };
 
   root.getCurrentFeeValue = function(currentSendFeeLevel, cb) { 


### PR DESCRIPTION
I don't think this will get merged, nor do I have a ton of time to work on it, nor do I have much skill with angular apps in general, but just making this PR to appease #3111.

Current Ideas:

- Are there any ways to make some sort of hurdle to using this feature? (Ideas: remove 'custom' from the "preferences" and only allow selecting it on a per transaction basis)
- Perhaps there should be a button to set it, and every time you click the button it pops up with a warning explaining why custom fees are a bad, horrible, insane idea.
- Perhaps there should be a high minimum fee for custom. (ie. The use case of "xyz service requires insane fees in order to do something" kinda makes sense, but imo that xyz service is stupid.) Setting a custom fee to 1000 satoshis just because you're a cheapskate should be discouraged. I propose minimum fee of `15000 satoshis x kB size of tx` for custom flat fee.
- Maybe have something like a special action to enable. (ex. you have to tap "Fee policy for this transaction" text 20 times in a row to enable the custom fee option etc.)

Current Questions:

- I can't seem to figure out where the feeLevels is actually being set. I have added an attribute to feeOpts with the string, but changing `feeService.getFeeLevels` for loop from i < 3 to i < 4 says that levelsLivenet[3] is undefined.