### PR TITLE
Hide menu if wallet is not authorized

### DIFF
--- a/public/views/includes/menu.html
+++ b/public/views/includes/menu.html
@@ -6,10 +6,10 @@
         <a></a>
     </div>
 
-    <menu-toggle ng-show="index.menu.length > 6"/>
+    <menu-toggle ng-show="index.menu.length > 6"></menu-toggle>
 </div>
 
-<div class="bottom-bar row collapse">
+<div ng-if="!index.notAuthorized" class="bottom-bar row collapse">
     <div ng-class="{ 'medium-10 small-10 columns': index.menu.length == 5 }">
         <div class="row collapse">
             <div class="medium-{{index.menuItemSize}} small-{{index.menuItemSize}} columns text-center bottombar-item"
@@ -17,7 +17,7 @@
               <span ng-include="'views/includes/menu-item.html'"/>
             </div>
 
-            <menu-toggle ng-show="index.menu.length > 6"/>
+            <menu-toggle ng-show="index.menu.length > 6"></menu-toggle>
         </div>
     </div>
 

--- a/public/views/walletHome.html
+++ b/public/views/walletHome.html
@@ -182,7 +182,7 @@
     receive
 
     -->
-    <div id="receive" class="receive tab-view">
+    <div id="receive" class="receive tab-view" ng-if="!index.notAuthorized">
 
       <div ng-show="index.needsBackup && !home.skipBackup" class="p60t row text-center">
         <div class="text-warning text-bold m15b">
@@ -280,7 +280,7 @@
     send
 
     -->
-    <div id="send" class="send tab-view">
+    <div id="send" class="send tab-view" ng-if="!index.notAuthorized">
       <div>
         <h4 class="title m0">
 
@@ -439,7 +439,7 @@
     history
 
     -->
-    <div id="history" class="history tab-view">
+    <div id="history" class="history tab-view" ng-if="!index.notAuthorized">
       <div class="row m20t" ng-show="!index.txHistory[0] && !index.updatingTxHistory">
         <div class="large-12 columns">
           <div class="oh text-center">


### PR DESCRIPTION
* Also hide `receive`, `send` and `history`.
* Fix menu-toggle element

fixes #3077