### PR TITLE
Self-signed certs from server

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "java": false,
     "plugin": false
   },
+  "chromium-args": "--allow-running-insecure-content --ignore-certificate-errors",
   "id": "jid1-x7bV5evAaI1P9Q",
   "homepage": "https://github.com/bitpay/copay",
   "license": "MIT",


### PR DESCRIPTION
- Right now, the behavior as it pertains to accepting self-signed certs in Copay is that non-node web kit version accept and node web kits versions do not
- Added chromium args to make this behavior consistent