### PR TITLE
Fix abwc version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   ],
   "dependencies": {
     "angular": "1.4.6",
-    "angular-bitcore-wallet-client": "~1.0.0",
+    "angular-bitcore-wallet-client": "0.6.4",
     "angular-foundation": "0.7.0",
     "angular-gettext": "2.1.0",
     "angular-moment": "0.10.1",


### PR DESCRIPTION
* The update to version 1.0.0 requires more test and modifications in some functions. So, in order to release a new version soon, we decided to use the previous (and stable) version of angular-bitcore-wallet-client.