### PR TITLE
do not encrypt profiles in mobile

### DIFF
--- a/src/js/services/storageService.js
+++ b/src/js/services/storageService.js
@@ -60,6 +60,11 @@ angular.module('copayApp.services')
 
         try {
           text = sjcl.decrypt(uuid, text);
+
+          $log.info('Migrating to unencrypted profile');
+          return storage.set('profile', text, function(err) {
+            return cb(err, text);
+          });
         } catch(e) {
           $log.warn('Decrypt error: ', e);
           return cb('Could not decrypt storage: device ID mismatch');

--- a/src/js/services/storageService.js
+++ b/src/js/services/storageService.js
@@ -25,13 +25,17 @@ angular.module('copayApp.services')
     };
 
     var encryptOnMobile = function(text, cb) {
-      getUUID(function(uuid) {
-        if (uuid) {
-          $log.debug('Encrypting profile');
-          text = sjcl.encrypt(uuid, text);
-        }
-        return cb(null, text);
-      });
+
+      // UUID encryption is disabled.
+      return cb(null, text);
+      //
+      // getUUID(function(uuid) {
+      //   if (uuid) {
+      //     $log.debug('Encrypting profile');
+      //     text = sjcl.encrypt(uuid, text);
+      //   }
+      //   return cb(null, text);
+      // });
     };
 
 
@@ -43,8 +47,10 @@ angular.module('copayApp.services')
 
       if (!json) return cb('Could not access storage')
 
-      if (!json.iter || !json.ct)
+      if (!json.iter || !json.ct) {
+        $log.debug('Profile is not encrypted');
         return cb(null, text);
+      }
 
       $log.debug('Profile is encrypted');
       getUUID(function(uuid) {
@@ -111,7 +117,6 @@ angular.module('copayApp.services')
       storage.get('profile', function(err, str) {
 
         if (err || !str)
-        // Migrate ?
           return cb(err);
 
         decryptOnMobile(str, function(err, str) {
@@ -120,6 +125,7 @@ angular.module('copayApp.services')
           try {
             p = Profile.fromString(str);
           } catch (e) {
+            $log.debug('Could not read profile:', e);
             err = new Error('Could not read profile:' + p);
           }
           return cb(err, p);


### PR DESCRIPTION
Disables UUID encryption on mobile devices, due to random problems detected on some Android devices, getting the UUID at startup.  

Encryption on mobile devices using UUID does not add significant protection anyways, and the user can still encrypt the xprivkey using it own password.

Manually tested on iOS simulators and iPhone 6.