### PR TITLE
hide delete is n=1, show err if sign failed

### DIFF
--- a/public/views/modals/txp-details.html
+++ b/public/views/modals/txp-details.html
@@ -156,7 +156,7 @@
     </div>
   </div>
 
-  <div class="columns text-center m20t" ng-if="tx.canBeRemoved">
+  <div class="columns text-center m20t" ng-if="tx.canBeRemoved && isShared">
     <div class="text-gray size-12 m20b" ng-if="!tx.isGlidera" translate>
       * A payment proposal can be deleted if 1) you are the creator, and no other copayer has signed, or 2) 24 hours have passed since the proposal was created.
     </div>

--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -271,6 +271,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
       $scope.canSign = fc.canSign() || fc.isPrivKeyExternal();
       $scope.loading = null;
       $scope.color = fc.backgroundColor;
+      $scope.isShared = fc.credentials.n > 1;
 
       // ToDo: use tx.customData instead of tx.message
       if (tx.message === 'Glidera transaction' && isGlidera) {
@@ -951,6 +952,9 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
     profileService.signTxProposal(txp, function(err, signedTx) {
       self.setOngoingProcess();
       if (err) {
+        if (!lodash.isObject(err)) {
+          err = { message: err};
+        }
         err.message = bwsError.msg(err, gettextCatalog.getString('The payment was created but could not be signed. Please try again from home screen'));
         return cb(err);
       }


### PR DESCRIPTION
Fixes: #3461

(hide 'delete' if n=1); show error, when error is not an object (ie: from a hardware wallet app)