### PR TITLE
sanitize wallet list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ webkitbuilds/*
 !webkitbuilds/build-osx.sh
 !webkitbuilds/Background.png
 
+
+
 # chrome extensions
 browser-extensions/chrome/copay-chrome-extension
 browser-extensions/chrome/copay-chrome-extension.zip
@@ -51,6 +53,7 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
 bower_components
+angular-bitcore-wallet-client/angular-bitcore-wallet-client.js
 
 # Users Environment Variables
 .lock-wscript

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,8 +61,8 @@ module.exports = function(grunt) {
           'bower_components/angular-qrcode/angular-qrcode.js',
           'bower_components/angular-gettext/dist/angular-gettext.js',
           'bower_components/angular-touch/angular-touch.js',
-          'bower_components/angular-bitcore-wallet-client/angular-bitcore-wallet-client.js',
-          'bower_components/angular-ui-switch/angular-ui-switch.js'
+          'bower_components/angular-ui-switch/angular-ui-switch.js',
+          'angular-bitcore-wallet-client/angular-bitcore-wallet-client.js'
         ],
         dest: 'public/lib/angular.js'
       },
@@ -112,8 +112,8 @@ module.exports = function(grunt) {
       pot: {
         files: {
           'i18n/po/template.pot': [
-            'public/index.html', 
-            'public/views/*.html', 
+            'public/index.html',
+            'public/views/*.html',
             'public/views/**/*.html',
             'src/js/routes.js',
             'src/js/services/*.js',
@@ -140,10 +140,21 @@ module.exports = function(grunt) {
         dest: 'public/icons/'
       },
       linux: {
-        files: [
-          {expand: true, cwd: 'webkitbuilds/',src: ['.desktop', '../public/img/icons/favicon.ico', '../public/img/icons/icon-256.png'],dest: 'webkitbuilds/copay/linux32/', flatten: true, filter: 'isFile' },
-          {expand: true, cwd: 'webkitbuilds/',src: ['.desktop', '../public/img/icons/favicon.ico', '../public/img/icons/icon-256.png'],dest: 'webkitbuilds/copay/linux64/', flatten: true, filter: 'isFile' },
-        ],
+        files: [{
+          expand: true,
+          cwd: 'webkitbuilds/',
+          src: ['.desktop', '../public/img/icons/favicon.ico', '../public/img/icons/icon-256.png'],
+          dest: 'webkitbuilds/copay/linux32/',
+          flatten: true,
+          filter: 'isFile'
+        }, {
+          expand: true,
+          cwd: 'webkitbuilds/',
+          src: ['.desktop', '../public/img/icons/favicon.ico', '../public/img/icons/icon-256.png'],
+          dest: 'webkitbuilds/copay/linux64/',
+          flatten: true,
+          filter: 'isFile'
+        }, ],
       }
     },
     karma: {
@@ -166,11 +177,11 @@ module.exports = function(grunt) {
     },
     nodewebkit: {
       options: {
-          platforms: ['win','osx','linux'],
-          buildDir: './webkitbuilds',
-          version: '0.12.2',
-          macIcns: './public/img/icons/icon.icns',
-          exeIco: './public/img/icons/icon.ico'
+        platforms: ['win', 'osx', 'linux'],
+        buildDir: './webkitbuilds',
+        version: '0.12.2',
+        macIcns: './public/img/icons/icon.icns',
+        exeIco: './public/img/icons/icon.ico'
       },
       src: ['./package.json', './public/**/*']
     },
@@ -193,6 +204,13 @@ module.exports = function(grunt) {
         src: ['**/*'],
         dest: 'copay-linux64/'
       }
+    },
+    browserify: {
+      dist: {
+        files: {
+          'angular-bitcore-wallet-client/angular-bitcore-wallet-client.js': ['angular-bitcore-wallet-client/index.js']
+        },
+      }
     }
   });
 
@@ -201,6 +219,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-angular-gettext');
+  grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks('grunt-exec');
   grunt.loadNpmTasks('grunt-karma');
   grunt.loadNpmTasks('grunt-karma-coveralls');

--- a/angular-bitcore-wallet-client/index.js
+++ b/angular-bitcore-wallet-client/index.js
@@ -1,0 +1,62 @@
+var bwcModule = angular.module('bwcModule', []);
+var Client = require('../node_modules/bitcore-wallet-client');
+
+bwcModule.constant('MODULE_VERSION', '1.0.0');
+
+bwcModule.provider("bwcService", function() {
+  var provider = {};
+
+  var config = {
+    baseUrl: 'https://bws.bitpay.com/bws/api',
+    verbose: null,
+    transports: null
+  };
+
+  provider.setBaseUrl = function(url) {
+    config.baseUrl = url;
+  };
+
+  provider.setVerbose = function(v) {
+    config.verbose = v ? true : false;
+  };
+
+  provider.$get = function() {
+    var service = {};
+
+    service.setBaseUrl = function(url) {
+      config.baseUrl = url;
+    };
+
+    service.setTransports = function(transports) {
+      config.transports = transports;
+    };
+
+    service.getBitcore = function() {
+      return Client.Bitcore;
+    };
+
+    service.getSJCL = function() {
+      return Client.sjcl;
+    };
+
+    service.buildTx = Client.buildTx;
+
+    service.getUtils = function() {
+      return Client.Utils;
+    };
+
+    service.getClient = function(walletData) {
+      var bwc = new Client({
+        baseUrl: config.baseUrl,
+        verbose: config.verbose,
+        transports: config.transports
+      });
+      if (walletData)
+        bwc.import(walletData);
+      return bwc;
+    };
+    return service;
+  };
+
+  return provider;
+});

--- a/package.json
+++ b/package.json
@@ -40,10 +40,12 @@
     "url": "https://github.com/bitpay/copay/issues"
   },
   "dependencies": {
+    "bitcore-wallet-client": "1.8.1",
     "express": "^4.11.2",
     "fs": "0.0.2",
     "grunt": "^0.4.5",
     "grunt-angular-gettext": "^0.2.15",
+    "grunt-browserify": "^4.0.1",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-compress": "^0.13.0",
     "grunt-contrib-concat": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/bitpay/copay/issues"
   },
   "dependencies": {
-    "bitcore-wallet-client": "1.8.1",
+    "bitcore-wallet-client": "1.1.9",
     "express": "^4.11.2",
     "fs": "0.0.2",
     "grunt": "^0.4.5",

--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -792,7 +792,6 @@ angular.module('copayApp.controllers').controller('indexController', function($r
       if (!txs || !txs[0]) return;
 
       var cacheUnit = txs[0].amountStr.split(' ')[1];
-      console.log('[index.js.794:cacheUnit:]', cacheUnit, config.unitName); //TODO
 
       if (cacheUnit == config.unitName)
         return;

--- a/src/js/controllers/sidebar.js
+++ b/src/js/controllers/sidebar.js
@@ -28,8 +28,7 @@ angular.module('copayApp.controllers').controller('sidebarController',
     self.switchWallet = function(selectedWalletId, currentWalletId) {
       if (selectedWalletId == currentWalletId) return;
       self.walletSelection = false;
-      profileService.setAndStoreFocus(selectedWalletId, function() {
-      });
+      profileService.setAndStoreFocus(selectedWalletId, function() {});
     };
 
     self.toggleWalletSelection = function() {
@@ -40,10 +39,14 @@ angular.module('copayApp.controllers').controller('sidebarController',
 
     self.setWallets = function() {
       if (!profileService.profile) return;
+
       var config = configService.getSync();
       config.colorFor = config.colorFor || {};
       config.aliasFor = config.aliasFor || {};
-      var ret = lodash.map(profileService.profile.credentials, function(c) {
+
+      // Sanitize empty wallets (fixed in BWC 1.8.1, and auto fixed when wallets completes)
+      var credentials = lodash.filter(profileService.profile.credentials, 'walletName');
+      var ret = lodash.map(credentials, function(c) {
         return {
           m: c.m,
           n: c.n,
@@ -52,6 +55,7 @@ angular.module('copayApp.controllers').controller('sidebarController',
           color: config.colorFor[c.walletId] || '#4A90E2',
         };
       });
+
       self.wallets = lodash.sortBy(ret, 'name');
     };
 


### PR DESCRIPTION
* Fix empty wallets at the sidebar
This happen when incomplete wallet are recovered from seed (fixed in BWC bitpay/bitcore-wallet-client#192), will be added in BWC in Copay 1.6.

If the wallet completes, it will appear (with its name) at the list

* Updates BWC with the mentioned fix
* Removes `angular-bitcore-wallet-client` dependency, and adds `bitcore-wallet-client`. Adds browserify to grunt.