### PR TITLE
Fix: configService.set() pollutes default config

### DIFF
--- a/src/js/services/configService.js
+++ b/src/js/services/configService.js
@@ -87,7 +87,7 @@ angular.module('copayApp.services').factory('configService', function(storageSer
   };
 
   root.set = function(newOpts, cb) {
-    var config = defaultConfig;
+    var config = lodash.clone(defaultConfig);
     storageService.getConfig(function(err, oldOpts) {
       if (lodash.isString(oldOpts)) {
         oldOpts = JSON.parse(oldOpts);


### PR DESCRIPTION
Call to ``configService.getDefaults()`` after ``configService.set(...)`` returned current config from storage, not the default config.