### PR TITLE
Fix ignoreMobilePause value on multiple pause/resume events

### DIFF
--- a/src/js/controllers/copayers.js
+++ b/src/js/controllers/copayers.js
@@ -9,6 +9,14 @@ angular.module('copayApp.controllers').controller('copayersController',
     var cancel_msg = gettextCatalog.getString('Cancel');
     var confirm_msg = gettextCatalog.getString('Confirm');
 
+    if (isMobile.Android() || isMobile.Windows()) {
+      $scope.$on('$destroy', function () {
+        $timeout(function () {
+          window.ignoreMobilePause = false;
+        }, 100);
+      });
+    }
+
     self.init = function() {
       var fc = profileService.focusedClient;
       if (fc.isComplete()) {

--- a/src/js/controllers/export.js
+++ b/src/js/controllers/export.js
@@ -10,6 +10,14 @@ angular.module('copayApp.controllers').controller('exportController',
     var fc = profileService.focusedClient;
     self.isEncrypted = fc.isPrivKeyEncrypted();
 
+    if (isMobile.Android() || isMobile.Windows()) {
+      $scope.$on('$destroy', function () {
+        $timeout(function () {
+          window.ignoreMobilePause = false;
+        }, 100);
+      });
+    }
+
     self.downloadWalletBackup = function() {
       self.getMetaData($scope.metaData, function(err, txsFromLocal, localAddressBook) {
         if (err) {

--- a/src/js/controllers/preferencesInformation.js
+++ b/src/js/controllers/preferencesInformation.js
@@ -6,6 +6,14 @@ angular.module('copayApp.controllers').controller('preferencesInformation',
     var fc = profileService.focusedClient;
     var c = fc.credentials;
 
+    if (isMobile.Android() || isMobile.Windows()) {
+      $scope.$on('$destroy', function () {
+        $timeout(function () {
+          window.ignoreMobilePause = false;
+        }, 100);
+      });
+    }
+
     this.init = function() {
       var basePath = c.getBaseAddressDerivationPath();
 

--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -27,6 +27,14 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
   this.isMobile = isMobile.any();
   this.addr = {};
 
+  if (isMobile.Android() || isMobile.Windows()) {
+    $scope.$on('$destroy', function () {
+      $timeout(function () {
+        window.ignoreMobilePause = false;
+      }, 100);
+    });
+  }
+
   var disableScannerListener = $rootScope.$on('dataScanned', function(event, data) {
     self.setForm(data);
     $rootScope.$emit('Local/SetTab', 'send');

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -44,9 +44,6 @@ angular.element(document).ready(function() {
             window.location = '#/cordova/resume///';
           }, 100);
         }
-        setTimeout(function() {
-          window.ignoreMobilePause = false;
-        }, 100);
       }, false);
 
       // Back button event


### PR DESCRIPTION
Hi, studying the source code I noticed a small bug in the pause/resume events handling. 
The bug is easily reproducible on mobile devices (I tried android):
* open copay
* go to wallet import 
* hide the app (go to device home with the home button) then reopen it, copay should remain in the wallet import state
* hide the app a second time and reopen it, now copay goes to the wallet home

Some controller like the importController sets the global variable `window.ignoreMobilePause = true` to avoid returning to walletHome state on resume event. In the init.js file on the resume event handler, the value of ignoreMobilePause is restored to false, the controller don't restore the "true" value so from the second resume event the skip doesn't work.

I opened this pull request with a possible solution, but **it is not tested**, I opened it for discussion.
In the proposed code the controllers that set to true ignoreMobilePause are responsible to restore the value to false. 
The importController and the qrScanner directive already do that, but not the other controllers.
Finally I removed the `window.ignoreMobilePause = false` in the resume event handler in init.js file.
