### PR TITLE
Fix automatic lock of focused client on timeout

### DIFF
--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -642,7 +642,7 @@ angular.module('copayApp.services')
           });
         }
         $timeout(function() {
-          if (fc.isPrivKeyEncrypted()) {
+          if (fc.hasPrivKeyEncrypted()) {
             $log.debug('Locking wallet automatically');
             root.lockFC();
           };


### PR DESCRIPTION
The profileService.unlockFC() method automatically locks the fc after 2 seconds but it doesn't work.
Before calling lockFC() it checks fc.isPrivKeyEncrypted(), but it is false after unlocked the fc, and if it is true it is not necessary to call lockFC(). In my opinion the ritght test should be on fc.hasPrivKeyEncrypted().