### PR TITLE
more storage for big wallet's history

### DIFF
--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -5,6 +5,7 @@
   "version": "APP_VERSION",
   "permissions": [
     "storage",
+    "unlimitedStorage",
     "notifications",
     "videoCapture",
     "webview"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "window": {
     "title": "Copay - A multisignature wallet",
     "icon": "./public/img/icons/icon-256.png",
-    "toolbar": true,
+    "toolbar": false,
     "show": true,
     "visible": true,
     "resizable": false,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "window": {
     "title": "Copay - A multisignature wallet",
     "icon": "./public/img/icons/icon-256.png",
-    "toolbar": false,
+    "toolbar": true,
     "show": true,
     "visible": true,
     "resizable": false,
@@ -29,6 +29,7 @@
     "java": false,
     "plugin": false
   },
+  "dom_storage_quota": 100,
   "id": "jid1-x7bV5evAaI1P9Q",
   "homepage": "https://github.com/bitpay/copay",
   "license": "MIT",


### PR DESCRIPTION
fixes storage for big wallets.


Windows PHone is still not support it for this (we use localStorage there, and the limitation is still 5MB)