### PR TITLE
Add error callback  to getFile() call

### DIFF
--- a/src/js/services/fileStorage.js
+++ b/src/js/services/fileStorage.js
@@ -116,8 +116,8 @@ angular.module('copayApp.services')
           fileEntry.remove(function() {
             console.log('File removed.');
             return cb();
-          }, cb, cb);
-        });
+          }, cb);
+        }, cb);
       });
     };
 


### PR DESCRIPTION
There is a missing error callback in dir.getFile() call and a duplicated parameter in the fileEntry.remove() call