### PR TITLE
Deactivate the auto-capitalize for the small tag

### DIFF
--- a/src/sass/forms.scss
+++ b/src/sass/forms.scss
@@ -301,6 +301,7 @@ label {
 label small {
   font-size: 10px;
   color: #999;
+  text-transform: none;
   &.has-error {
     font-size: 11px;
   }


### PR DESCRIPTION
### After

![sans titre](https://cloud.githubusercontent.com/assets/6627786/15800042/cf85473c-2a6f-11e6-9b40-7e0ea873633f.png)
