### PR TITLE
Export refactor

### DIFF
--- a/public/views/export.html
+++ b/public/views/export.html
@@ -39,10 +39,6 @@
 
       <h4></h4>
 
-      <ion-toggle ng-model="metaDataEnabled" toggle-class="toggle-balanced" class="r0">
-        <span class="toggle-label" translate>Include address book and history cache</span>
-      </ion-toggle>
-
       <ion-toggle ng-model="noSignEnabled" toggle-class="toggle-balanced" class="r0">
         <span class="toggle-label" translate>Do not include private key</span>
       </ion-toggle>

--- a/src/js/controllers/export.js
+++ b/src/js/controllers/export.js
@@ -1,25 +1,23 @@
 'use strict';
 
 angular.module('copayApp.controllers').controller('exportController',
-  function($rootScope, $scope, $timeout, $log, backupService, storageService, profileService, platformInfo, notification, go, gettext, gettextCatalog) {
+  function($scope, $timeout, $log, backupService, storageService, profileService, platformInfo, notification, go, gettext, gettextCatalog) {
     var isWP = platformInfo.isWP;
     var isAndroid = platformInfo.isAndroid;
 
     $scope.error = null;
     $scope.success = null;
-    $scope.metaDataEnabled = true;
     var fc = profileService.focusedClient;
     $scope.isEncrypted = fc.isPrivKeyEncrypted();
 
     $scope.downloadWalletBackup = function() {
-      $scope.getMetaData($scope.metaDataEnabled, function(err, txsFromLocal, localAddressBook) {
+      $scope.getAddressbook(function(err, localAddressBook) {
         if (err) {
           $scope.error = true;
           return;
         }
         var opts = {
           noSign: $scope.noSignEnabled,
-          historyCache: txsFromLocal,
           addressBook: localAddressBook
         };
 
@@ -28,42 +26,11 @@ angular.module('copayApp.controllers').controller('exportController',
             $scope.error = true;
             return;
           }
-          $rootScope.$emit('Local/BackupDone');
           notification.success(gettext('Success'), gettext('Encrypted export file saved'));
           go.walletHome();
         });
       });
     };
-
-    $scope.getMetaData = function(metaData, cb) {
-      if (metaData == false) return cb();
-      $scope.getHistoryCache(function(err, txsFromLocal) {
-        if (err) return cb(err);
-
-        $scope.getAddressbook(function(err, localAddressBook) {
-          if (err) return cb(err);
-
-          return cb(null, txsFromLocal, localAddressBook)
-        });
-      });
-    }
-
-    $scope.getHistoryCache = function(cb) {
-      storageService.getTxHistory(fc.credentials.walletId, function(err, txs) {
-        if (err) return cb(err);
-
-        var localTxs = [];
-
-        try {
-          localTxs = JSON.parse(txs);
-        } catch (ex) {
-          $log.warn(ex);
-        }
-        if (!localTxs[0]) return cb(null, null);
-
-        return cb(null, localTxs);
-      });
-    }
 
     $scope.getAddressbook = function(cb) {
       storageService.getAddressbook(fc.credentials.network, function(err, addressBook) {
@@ -81,14 +48,13 @@ angular.module('copayApp.controllers').controller('exportController',
     }
 
     $scope.getBackup = function(cb) {
-      $scope.getMetaData($scope.metaDataEnabled, function(err, txsFromLocal, localAddressBook) {
+      $scope.getAddressbook(function(err, localAddressBook) {
         if (err) {
           $scope.error = true;
           return cb(null);
         }
         var opts = {
           noSign: $scope.noSignEnabled,
-          historyCache: txsFromLocal,
           addressBook: localAddressBook
         };
 
@@ -97,7 +63,6 @@ angular.module('copayApp.controllers').controller('exportController',
           $scope.error = true;
         } else {
           $scope.error = false;
-          $rootScope.$emit('Local/BackupDone');
         }
         return cb(ew);
       });

--- a/src/js/services/backupService.js
+++ b/src/js/services/backupService.js
@@ -40,7 +40,7 @@ angular.module('copayApp.services')
 
       var a = angular.element('<a></a>');
       var blob = new NewBlob(ew, 'text/plain;charset=utf-8');
-      a.attr('href',window.URL.createObjectURL(blob));
+      a.attr('href', window.URL.createObjectURL(blob));
       a.attr('download', filename);
       a[0].click();
       return cb();
@@ -49,7 +49,6 @@ angular.module('copayApp.services')
     root.addMetadata = function(b, opts) {
 
       b = JSON.parse(b);
-      if (opts.historyCache) b.historyCache = opts.historyCache;
       if (opts.addressBook) b.addressBook = opts.addressBook;
       return JSON.stringify(b);
     }
@@ -62,7 +61,7 @@ angular.module('copayApp.services')
       try {
         opts = opts || {};
         var b = fc.export(opts);
-        if (opts.historyCache || opts.addressBook) b = root.addMetadata(b, opts);
+        if (opts.addressBook) b = root.addMetadata(b, opts);
 
         var e = sjcl.encrypt(password, b, {
           iter: 10000

--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -449,7 +449,7 @@ angular.module('copayApp.services')
       });
     };
 
-    root.setMetaData = function(walletClient, addressBook, historyCache, cb) {
+    root.setMetaData = function(walletClient, addressBook, cb) {
       storageService.getAddressbook(walletClient.credentials.network, function(err, localAddressBook) {
         var localAddressBook1 = {};
         try {
@@ -460,10 +460,7 @@ angular.module('copayApp.services')
         var mergeAddressBook = lodash.merge(addressBook, localAddressBook1);
         storageService.setAddressbook(walletClient.credentials.network, JSON.stringify(addressBook), function(err) {
           if (err) return cb(err);
-          storageService.setTxHistory(JSON.stringify(historyCache), walletClient.credentials.walletId, function(err) {
-            if (err) return cb(err);
-            return cb(null);
-          });
+          return cb(null);
         });
       });
     }
@@ -549,13 +546,12 @@ angular.module('copayApp.services')
       str = JSON.parse(str);
 
       var addressBook = str.addressBook || {};
-      var historyCache = str.historyCache ||  [];
 
       root.addAndBindWalletClient(walletClient, {
         bwsurl: opts.bwsurl
       }, function(err, walletId) {
         if (err) return cb(err);
-        root.setMetaData(walletClient, addressBook, historyCache, function(error) {
+        root.setMetaData(walletClient, addressBook, function(error) {
           if (error) $log.warn(error);
           return cb(err, walletId);
         });


### PR DESCRIPTION
- Remove including history cache option from export (long transactions histories are imposible to copy) fixes:  #4189

- Remove "backup done" flag from export (the user should always get through 12 words flow)

- Include always address book when exporting file.