### PR TITLE
Move hardcoded insight button url to config

### DIFF
--- a/public/views/modals/tx-details.html
+++ b/public/views/modals/tx-details.html
@@ -149,8 +149,7 @@
 
       <div ng-show="btx.txid" class="tx-details-blockchain">
         <div class="text-center m20t">
-          <button class="button outline round dark-gray tiny" ng-click="$root.openExternalLink('https://' +
-            (getShortNetworkName() == 'test' ? 'test-' : '') + 'insight.bitpay.com/tx/' + btx.txid)">
+          <button class="button outline round dark-gray tiny" ng-click="$root.openExternalLink(txurl)">
             <span class="text-gray" translate>See it on the blockchain</span>
           </button>
           <button class="button outline round dark-gray tiny" ng-click="showCommentPopup()">

--- a/public/views/preferencesAdvanced.html
+++ b/public/views/preferencesAdvanced.html
@@ -30,6 +30,11 @@
       <div>Wallet Service URL</div>
     </li>
 
+    <li  href ui-sref="preferencesTxUrl">
+      <i class="icon-arrow-right3 size-24 right text-gray"></i>
+      <div>Transaction URL</div>
+    </li>
+
      <li href ui-sref="preferencesHistory">
       <i class="icon-arrow-right3 size-24 right text-gray"></i>
       <div translate>Transaction History</div>

--- a/public/views/preferencesTxUrl.html
+++ b/public/views/preferencesTxUrl.html
@@ -1,0 +1,17 @@
+<div
+  class="topbar-container"
+  ng-include="'views/includes/topbar.html'"
+  ng-init="titleSection='Transaction URL'; goBackToState = 'preferencesAdvanced';">
+</div>
+
+<div class="content preferences" ng-controller="preferencesTxUrlController">
+  <h4></h4>
+  <form name="settingsBwsUrlForm" ng-submit="save()" class="columns">
+    <label class="left">Transaction URL</label>
+    <a class="right size-12" ng-click="resetDefaultUrl()" translate> Set default url</a>
+    <input type="text" id="txurl" type="text" name="txurl" ng-model="txurl">
+    <input type="submit" class="button expand black round" value="{{'Save'|translate}}"
+    ng-style="{'background-color':index.backgroundColor}">
+  </form>
+</div>
+<div class="extra-margin-bottom"></div>

--- a/src/js/controllers/modals/txDetails.js
+++ b/src/js/controllers/modals/txDetails.js
@@ -4,6 +4,8 @@ angular.module('copayApp.controllers').controller('txDetailsController', functio
 
   var self = $scope.self;
   var fc = profileService.focusedClient;
+  var walletId = fc.credentials.walletId;
+  var defaults = configService.getDefaults();
   var config = configService.getSync();
   var configWallet = config.wallet;
   var walletSettings = configWallet.settings;
@@ -93,5 +95,8 @@ angular.module('copayApp.controllers').controller('txDetailsController', functio
   $scope.cancel = function() {
     $scope.txDetailsModal.hide();
   };
+
+  var txurl = (config.txFor && config.txFor[walletId]) || defaults.tx.url;
+  $scope.txurl = $scope.txurl.replace(/\$\{txid\}/gi, $scope.btx.txid);
 
 });

--- a/src/js/controllers/preferencesTxUrl.js
+++ b/src/js/controllers/preferencesTxUrl.js
@@ -1,0 +1,53 @@
+'use strict';
+
+angular.module('copayApp.controllers').controller('preferencesTxUrlController',
+  function($scope, $log, configService, applicationService, profileService, storageService) {
+    $scope.error = null;
+    $scope.success = null;
+
+    var fc = profileService.focusedClient;
+    var walletId = fc.credentials.walletId;
+    var defaults = configService.getDefaults();
+    var config = configService.getSync();
+
+    $scope.txurl = (config.txFor && config.txFor[walletId]) || defaults.tx.url;
+
+    $scope.resetDefaultUrl = function() {
+      $scope.txurl = defaults.tx.url;
+    };
+
+    $scope.save = function() {
+
+      var tx;
+      switch ($scope.txurl) {
+        case 'prod':
+        case 'production':
+          tx = 'https://insight.bitpay.com/tx/${txid}'
+          break;
+        case 'sta':
+        case 'staging':
+          tx = 'https://test-insight.bitpay.com/tx/${txid}'
+          break;
+        case 'loc':
+        case 'local':
+          tx = 'http://localhost:3001/insight/tx/${txid}'
+          break;
+      };
+      if (tx) {
+        $log.info('Using transaction URL Alias to ' + tx);
+        $scope.txurl = tx;
+      }
+
+      var opts = {
+        txFor: {}
+      };
+      opts.txFor[walletId] = $scope.txurl;
+
+      configService.set(opts, function(err) {
+        if (err) $log.debug(err);
+        storageService.setCleanAndScanAddresses(walletId, function() {
+          applicationService.restart();
+        });
+      });
+    };
+  });

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -428,6 +428,18 @@ angular.module('copayApp').config(function(historicLogProvider, $provide, $logPr
 
         }
       })
+      .state('preferencesTxUrl', {
+        url: '/preferencesTxUrl',
+        templateUrl: 'views/preferencesTxUrl.html',
+        walletShouldBeComplete: true,
+        needProfile: true,
+        views: {
+          'main': {
+            templateUrl: 'views/preferencesTxUrl.html'
+          },
+
+        }
+      })
       .state('preferencesHistory', {
         url: '/preferencesHistory',
         templateUrl: 'views/preferencesHistory.html',

--- a/src/js/services/configService.js
+++ b/src/js/services/configService.js
@@ -15,6 +15,11 @@ angular.module('copayApp.services').factory('configService', function(storageSer
       url: 'https://bws.bitpay.com/bws/api',
     },
 
+    // Transaction URL
+    tx: {
+      url: 'https://insight.bitpay.com/tx/${txid}',
+    },
+
     // wallet default config
     wallet: {
       requiredCopayers: 2,


### PR DESCRIPTION
The main purpose of this pull request is to add an advanced option that lets users change where the "See it on the blockchain" button links to. This will allow users to choose their blockchain explorer like they can currently choose their wallet service. At present, it's hard coded in the button itself to either link to production or test. 

Originally it was checking if the short network name started with the word "test" and if so, added "test-" to the start of the url. I have removed this feature as you can now enter any url you want to. However, if you want to retain the check for this, just let me know.

I noticed that the BWS url doesn't have a trailing /, so at first I wrote the transaction url to be the same,  where it just added it for them. The problem with this is that, potentially, different blockchain explorers may use the txid differently such as part of a query or a hash. I have opted to use a token instead so that the id can be placed anywhere in the url string and as many times as the user needs.