### PR TITLE
Use more explicit logic in fee level check

### DIFF
--- a/src/js/services/feeService.js
+++ b/src/js/services/feeService.js
@@ -30,7 +30,7 @@ angular.module('copayApp.services').factory('feeService', function($log, $stateP
       var feeLevelValue = lodash.find(levels, {
         level: feeLevel
       });
-      if (!feeLevelValue || !feeLevelValue.feePerKB)
+      if (!feeLevelValue || feeLevelValue.feePerKB == null)
         return cb({
           message: 'Could not get dynamic fee for level: ' + feeLevel
         });


### PR DESCRIPTION
Bitcore-Wallet-Service allows for a minimum fee of `0`, however if this is the case it will currently cause Copay errors. These problems are caused by the `!feeLevelBalue.feePerKb` checks that return true on a case of `0`.

This PR only solves half of the problem as there is a similar check in Bitcore-Wallet-Client which I have also created a [pull request](https://github.com/bitpay/bitcore-wallet-client/pull/320) for.
