### PR TITLE
Locking amount on paypro only if sum of outputs great than zero

### DIFF
--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -616,7 +616,7 @@ angular.module('copayApp.controllers').controller('walletHomeController', functi
       this.lockAddress = true;
     }
 
-    if (amount) {
+    if (amount > 0) {
       form.amount.$setViewValue("" + amount);
       form.amount.$isValid = true;
       form.amount.$render();


### PR DESCRIPTION
Allows user-specified amounts on paypro as per  [bip70](https://github.com/bitcoin/bips/blob/master/bip-0070.mediawiki#paymentdetailspaymentrequest):

> 
**outputs**: one or more outputs where Bitcoins are to be sent. **If the sum of outputs.amount is zero, the customer will be asked how much to pay**, and the bitcoin client may choose any or all of the Outputs (if there are more than one) for payment. If the sum of outputs.amount is non-zero, then the customer will be asked to pay the sum, and the payment shall be split among the Outputs with non-zero amounts (if there are more than one; Outputs with zero amounts shall be ignored).

