### PR TITLE
remove to show backup needed modal automatically when clicking on receive view

### DIFF
--- a/src/js/controllers/backup.js
+++ b/src/js/controllers/backup.js
@@ -131,7 +131,6 @@ angular.module('copayApp.controllers').controller('backupController',
         }
 
         profileService.setBackupFlag(wallet.credentials.walletId);
-        profileService.setBackupNeededModalFlag(wallet.credentials.walletId);
         return cb();
       }, 1);
     };

--- a/src/js/controllers/tab-receive.js
+++ b/src/js/controllers/tab-receive.js
@@ -12,11 +12,11 @@ angular.module('copayApp.controllers').controller('tabReceiveController', functi
     }
   };
 
-  $scope.setAddress = function(forceNew, wallet) {
-    if (!wallet || $scope.generatingAddress || !wallet.isComplete()) return;
+  $scope.setAddress = function(forceNew) {
+    if (!$scope.wallet || $scope.generatingAddress || !$scope.wallet.isComplete()) return;
     $scope.addr = null;
     $scope.generatingAddress = true;
-    walletService.getAddress(wallet, forceNew, function(err, addr) {
+    walletService.getAddress($scope.wallet, forceNew, function(err, addr) {
       $scope.generatingAddress = false;
       if (err) popupService.showAlert(gettextCatalog.getString('Error'), err);
       $scope.addr = addr;
@@ -80,7 +80,7 @@ angular.module('copayApp.controllers').controller('tabReceiveController', functi
     $scope.generatingAddress = false;
     $log.debug('Wallet changed: ' + wallet.name);
     $timeout(function() {
-      $scope.setAddress(false, wallet);
+      $scope.setAddress(false);
     }, 100);
   });
 

--- a/src/js/controllers/tab-receive.js
+++ b/src/js/controllers/tab-receive.js
@@ -4,7 +4,6 @@ angular.module('copayApp.controllers').controller('tabReceiveController', functi
 
   $scope.isCordova = platformInfo.isCordova;
   $scope.isNW = platformInfo.isNW;
-  var showModalTimeout;
 
   $scope.shareAddress = function(addr) {
     if ($scope.generatingAddress) return;
@@ -13,19 +12,14 @@ angular.module('copayApp.controllers').controller('tabReceiveController', functi
     }
   };
 
-  $scope.setAddress = function(forceNew) {
-    if (!$scope.wallet || $scope.generatingAddress || !$scope.wallet.isComplete()) return;
+  $scope.setAddress = function(forceNew, wallet) {
+    if (!wallet || $scope.generatingAddress || !wallet.isComplete()) return;
     $scope.addr = null;
     $scope.generatingAddress = true;
-    walletService.getAddress($scope.wallet, forceNew, function(err, addr) {
+    walletService.getAddress(wallet, forceNew, function(err, addr) {
       $scope.generatingAddress = false;
       if (err) popupService.showAlert(gettextCatalog.getString('Error'), err);
       $scope.addr = addr;
-      if ($scope.wallet.showBackupNeededModal) {
-        showModalTimeout = $timeout(function() {
-          $scope.openBackupNeededModal();
-        }, 2000);
-      }
       $timeout(function() {
         $scope.$apply();
       }, 10);
@@ -59,7 +53,6 @@ angular.module('copayApp.controllers').controller('tabReceiveController', functi
   $scope.close = function() {
     $scope.BackupNeededModal.hide();
     $scope.BackupNeededModal.remove();
-    profileService.setBackupNeededModalFlag($scope.wallet.credentials.walletId);
   };
 
   $scope.doBackup = function() {
@@ -84,14 +77,11 @@ angular.module('copayApp.controllers').controller('tabReceiveController', functi
       return;
     }
     $scope.wallet = wallet;
+    $scope.generatingAddress = false;
     $log.debug('Wallet changed: ' + wallet.name);
     $timeout(function() {
-      $scope.setAddress();
+      $scope.setAddress(false, wallet);
     }, 100);
-  });
-
-  $scope.$on("$ionicView.leave", function(event, data) {
-    $timeout.cancel(showModalTimeout);
   });
 
   $scope.$on("$ionicView.beforeEnter", function(event, data) {

--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -38,22 +38,6 @@ angular.module('copayApp.services')
       });
     }
 
-    root.setBackupNeededModalFlag = function(walletId) {
-      storageService.setBackupNeededModalFlag(walletId, true, function(err) {
-        if (err) $log.error(err);
-        $log.debug('Backup warning modal flag stored');
-        root.wallet[walletId].showBackupNeededModal = false;
-      });
-    };
-
-    function _showBackupNeededModal(wallet, cb) {
-      storageService.getBackupNeededModalFlag(wallet.credentials.walletId, function(err, val) {
-        if (err) $log.error(err);
-        if (val) return cb(false);
-        return cb(true);
-      });
-    };
-
     root.setBackupFlag = function(walletId) {
       storageService.setBackupFlag(walletId, function(err) {
         if (err) $log.error(err);
@@ -115,11 +99,6 @@ angular.module('copayApp.services')
 
       _balanceIsHidden(wallet, function(val) {
         wallet.balanceHidden = val;
-      });
-
-      _showBackupNeededModal(wallet, function(val) {
-        if (wallet.needsBackup) wallet.showBackupNeededModal = val;
-        else wallet.showBackupNeededModal = false;
       });
 
       wallet.removeAllListeners();

--- a/src/js/services/storageService.js
+++ b/src/js/services/storageService.js
@@ -373,15 +373,6 @@ angular.module('copayApp.services')
       });
     };
 
-
-    root.setBackupNeededModalFlag = function(walletId, val, cb) {
-      storage.set('showBackupNeededModal-' + walletId, val, cb);
-    };
-
-    root.getBackupNeededModalFlag = function(walletId, cb) {
-      storage.get('showBackupNeededModal-' + walletId, cb);
-    };
-
     root.setAmazonGiftCards = function(network, gcs, cb) {
       storage.set('amazonGiftCards-' + network, gcs, cb);
     };

--- a/src/sass/views/includes/modals/modals.scss
+++ b/src/sass/views/includes/modals/modals.scss
@@ -69,5 +69,9 @@
   }
 }
 
+.modal-backdrop.active {
+   background: rgba(0, 0, 0, .8);
+ }
+
 @import "backup-needed-modal";
 @import "screenshot-warning-model";

--- a/www/views/includes/backupNeededPopup.html
+++ b/www/views/includes/backupNeededPopup.html
@@ -7,7 +7,7 @@
       <div class="popup-modal-heading" translate>Backup Needed</div>
       <div class="popup-modal-message" translate>Now is a good time to backup your wallet. If this device is lost, it is impossible to access your funds without a backup.</div>
       <button class="button button-clear" ng-click="doBackup()" translate>Backup now</button>
-      <button class="button button-secondary button-clear" ng-click="close()" translate>Remind me later</button>
+      <button class="button button-secondary button-clear" ng-click="close()" translate>I'll do it later</button>
     </div>
   </div>
 </div>

--- a/www/views/tab-receive.html
+++ b/www/views/tab-receive.html
@@ -46,7 +46,7 @@
         </div>
       </article>
       <article ng-if="wallet && wallet.isComplete()">
-        <div class="row backup" ng-show="!wallet.showBackupNeededModal && wallet.needsBackup" ng-click="goToBackupFlow()">
+        <div class="row backup" ng-show="wallet.needsBackup" ng-click="openBackupNeededModal()">
           <div class="text-center col center-block">
             <i class="icon ion-alert"></i><span translate>Wallet not backed up</span><i class="icon ion-ios-arrow-thin-right"></i>
           </div>


### PR DESCRIPTION
I think we should keep it simple. There are so much issues with this feature. 

-  Clicking on Receive tab and immediately on other shows the modal, but sometimes no.  Sometimes the 'Wallet/Changed' event fires when we are out that view.
-  Sometimes the 'Wallet/Changed' is not fired and the modal do not show at all.
- When the modal is not shown the top label is also not shown.

Maybe we could create a an issue to add this feature again later.