### PR TITLE
Add toggle for email notifications

### DIFF
--- a/src/js/controllers/preferencesNotifications.js
+++ b/src/js/controllers/preferencesNotifications.js
@@ -1,49 +1,62 @@
 'use strict';
 
-angular.module('copayApp.controllers').controller('preferencesNotificationsController',
-  function($scope, $rootScope, $log, $window, lodash, configService, uxLanguage, platformInfo, pushNotificationsService, profileService, feeService) {
+angular.module('copayApp.controllers').controller('preferencesNotificationsController', function($scope, $log, $window, configService, platformInfo, pushNotificationsService, profileService, emailService) {
+  var updateConfig = function() {
+    $scope.appName = $window.appConfig.nameCase;
+    $scope.PNEnabledByUser = true;
+    $scope.usePushNotifications = platformInfo.isCordova && !platformInfo.isWP;
+    $scope.isIOSApp = platformInfo.isIOS && platformInfo.isCordova;
 
-    var updateConfig = function() {
+    if ($scope.isIOSApp) {
+      try {
+        PushNotification.hasPermission(function(data) {
+          $scope.PNEnabledByUser = data.isEnabled;
+        });
+      } catch (e) {
+        $log.error(e);
+      };
+    }
 
-      var config = configService.getSync();
-      var isCordova = platformInfo.isCordova;
-      var isIOS = platformInfo.isIOS;
+    var config = configService.getSync();
 
-      $scope.appName = $window.appConfig.nameCase;
-      $scope.PNEnabledByUser = true;
-      $scope.isIOSApp = isIOS && isCordova;
-      if ($scope.isIOSApp) {
-        try {
-          PushNotification.hasPermission(function(data) {
-            $scope.PNEnabledByUser = data.isEnabled;
-          });
-        } catch(e) {
-          $log.error(e);
-        };
+    $scope.pushNotifications = {
+      value: config.pushNotifications.enabled
+    };
+
+    $scope.emailNotifications = {
+      value: config.emailNotifications ? config.emailNotifications.enabled : false
+    };
+  };
+
+  $scope.pushNotificationsChange = function() {
+    if (!$scope.pushNotifications) return;
+    var opts = {
+      pushNotifications: {
+        enabled: $scope.pushNotifications.value
       }
-
-      $scope.pushNotifications = {
-        value: config.pushNotifications.enabled
-      };
     };
-
-    $scope.pushNotificationsChange = function() {
-      if (!$scope.pushNotifications) return;
-      var opts = {
-        pushNotifications: {
-          enabled: $scope.pushNotifications.value
-        }
-      };
-      configService.set(opts, function(err) {
-        if (opts.pushNotifications.enabled)
-          profileService.pushNotificationsInit();
-        else
-          pushNotificationsService.disableNotifications(profileService.getWallets());
-        if (err) $log.debug(err);
-      });
-    };
-
-    $scope.$on("$ionicView.enter", function(event, data) {
-      updateConfig();
+    configService.set(opts, function(err) {
+      if (opts.pushNotifications.enabled)
+        profileService.pushNotificationsInit();
+      else
+        pushNotificationsService.disableNotifications(profileService.getWallets());
+      if (err) $log.debug(err);
     });
+  };
+
+  $scope.emailNotificationsChange = function() {
+    var opts = {
+      emailNotifications: {
+        enabled: $scope.emailNotifications.value
+      }
+    };
+    emailService.enableEmailNotifications($scope.emailNotifications.value);
+    configService.set(opts, function(err) {
+      if (err) $log.debug(err);
+    });
+  };
+
+  $scope.$on("$ionicView.enter", function(event, data) {
+    updateConfig();
   });
+});

--- a/src/js/controllers/tab-settings.js
+++ b/src/js/controllers/tab-settings.js
@@ -1,17 +1,11 @@
 'use strict';
 
-angular.module('copayApp.controllers').controller('tabSettingsController', function($scope, $window, uxLanguage, platformInfo, profileService, feeService, configService, externalLinkService) {
+angular.module('copayApp.controllers').controller('tabSettingsController', function($scope, $window, uxLanguage, profileService, feeService, configService, externalLinkService) {
 
   var updateConfig = function() {
-
-    var config = configService.getSync();
-    var isCordova = platformInfo.isCordova;
-    var isWP = platformInfo.isWP;
-
-    $scope.usePushNotifications = isCordova && !isWP;
-
     $scope.appName = $window.appConfig.nameCase;
 
+    var config = configService.getSync();
     $scope.unitName = config.wallet.settings.unitName;
     $scope.currentLanguageName = uxLanguage.getCurrentLanguageName();
     $scope.selectedAlternative = {

--- a/src/js/services/configService.js
+++ b/src/js/services/configService.js
@@ -85,6 +85,10 @@ angular.module('copayApp.services').factory('configService', function(storageSer
         windows: {},
       }
     },
+
+    emailNotifications: {
+      enabled: true,
+    },
   };
 
   var configCache = null;

--- a/src/js/services/emailService.js
+++ b/src/js/services/emailService.js
@@ -1,0 +1,36 @@
+'use strict';
+
+angular.module('copayApp.services').factory('emailService', function($log, configService, profileService, lodash, walletService) {
+  var root = {};
+
+  root.enableEmailNotifications = function(val) {
+    val = val || false;
+
+    var config = configService.getSync();
+
+    if (!config.emailFor) {
+      $log.debug('No email configuration available');
+      return;
+    }
+
+    var keys = lodash.keys(config.emailFor);
+    var wallets = lodash.map(keys, function(k) {
+      return profileService.getWallet(k);
+    });
+
+    if (!wallets) {
+      $log.debug('No wallets found');
+      return;
+    }
+
+    lodash.each(wallets, function(w) {
+      walletService.updateRemotePreferences(w, {
+        email: val ? config.emailFor[w.credentials.walletId] : null
+      }, function(err) {
+        if (err) $log.warn(err);
+      });
+    });
+  };
+
+  return root;
+});

--- a/www/views/preferencesNotifications.html
+++ b/www/views/preferencesNotifications.html
@@ -10,8 +10,12 @@
       <div ng-show="PNEnabledByUser">
         <div class="item item-divider" translate>Notifications</div>
 
-        <ion-toggle ng-model="pushNotifications.value" toggle-class="toggle-balanced" ng-change="pushNotificationsChange()">
+        <ion-toggle ng-model="pushNotifications.value" toggle-class="toggle-balanced" ng-change="pushNotificationsChange()" ng-show="usePushNotifications">
           <span class="toggle-label" translate>Enable push notifications</span>
+        </ion-toggle>
+
+        <ion-toggle ng-model="emailNotifications.value" toggle-class="toggle-balanced" ng-change="emailNotificationsChange()">
+          <span class="toggle-label" translate>Enable email notifications</span>
         </ion-toggle>
       </div>
 

--- a/www/views/tab-settings.html
+++ b/www/views/tab-settings.html
@@ -39,7 +39,7 @@
 
       <div class="item item-divider" translate>Preferences</div>
 
-      <a class="item item-icon-left item-icon-right" ui-sref="tabs.notifications" ng-show="usePushNotifications">
+      <a class="item item-icon-left item-icon-right" ui-sref="tabs.notifications">
         <i class="icon big-icon-svg">
           <img src="img/icon-notifications.svg" class="bg"/>
         </i>


### PR DESCRIPTION
Closes #4844

* Add enable email notifications toggle in settings, notifications option
* Hide push notification toggle if it isn't mobile

<img width="416" alt="bitpay_-_secure_bitcoin_wallet" src="https://cloud.githubusercontent.com/assets/13851807/19807969/e96e783e-9cf8-11e6-8f10-bfbd47db02f9.png">

<img width="412" alt="bitpay_-_secure_bitcoin_wallet" src="https://cloud.githubusercontent.com/assets/13851807/19807987/fabc73ca-9cf8-11e6-9c9e-5ff79d29d011.png">

> Enable it to save remote preferences with the current email settings (if exist) on storage
> Disable it to save remote preferences with empty salues on email settings