### PR TITLE
Allow user-defined amounts when paypro request amount is zero

### DIFF
--- a/src/js/controllers/amount.js
+++ b/src/js/controllers/amount.js
@@ -23,6 +23,8 @@ angular.module('copayApp.controllers').controller('amountController', function($
     $scope.toEmail = data.stateParams.toEmail;
     $scope.showAlternativeAmount = !!$scope.cardId;
     $scope.toColor = data.stateParams.toColor;
+    $scope.paypro = data.stateParams.paypro;
+    $scope.description = data.stateParams.description;
 
     if (!$scope.cardId && !$stateParams.toAddress) {
       $log.error('Bad params at amount')
@@ -245,7 +247,9 @@ angular.module('copayApp.controllers').controller('amountController', function($
         toAmount: amount * unitToSatoshi,
         toAddress: $scope.toAddress,
         toName: $scope.toName,
-        toEmail: $scope.toEmail
+        toEmail: $scope.toEmail,
+        paypro: $scope.paypro,
+        description: $scope.description
       });
     }
   };

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -260,13 +260,14 @@ angular.module('copayApp').config(function(historicLogProvider, $provide, $logPr
      */
 
     .state('tabs.send.amount', {
-        url: '/amount/:isWallet/:toAddress/:toName/:toEmail/:toColor',
+        url: '/amount/:isWallet/:toAddress/:toName/:toEmail/:toColor/:description',
         views: {
           'tab-send@tabs': {
             controller: 'amountController',
             templateUrl: 'views/amount.html'
           }
-        }
+        },
+        params: { paypro: null }
       })
       .state('tabs.send.confirm', {
         url: '/confirm/:isWallet/:toAddress/:toName/:toAmount/:toEmail/:description',

--- a/src/js/services/incomingData.js
+++ b/src/js/services/incomingData.js
@@ -152,7 +152,9 @@ angular.module('copayApp.services').factory('incomingData', function($log, $stat
     scannerService.pausePreview();
     $state.go('tabs.send').then(function() {
       $timeout(function() {
-        $state.transitionTo('tabs.send.confirm', stateParams);
+        $state.transitionTo(stateParams.toAmount
+          ? 'tabs.send.confirm'
+          : 'tabs.send.amount', stateParams);
       });
     });
   }

--- a/src/js/services/txFormatService.js
+++ b/src/js/services/txFormatService.js
@@ -18,7 +18,7 @@ angular.module('copayApp.services').factory('txFormatService', function(bwcServi
   };
 
   root.formatAmountStr = function(satoshis) {
-    if (!satoshis) return;
+    if (!satoshis && satoshis !== 0) return;
     var config = configService.getSync().wallet.settings;
     return root.formatAmount(satoshis) + ' ' + config.unitName;
   };


### PR DESCRIPTION
Same as #4801 but updated for the last version. Routes through the amount controller if required before going into confirm.
