### PR TITLE
Update Help Center Link

### DIFF
--- a/www/views/tab-settings.html
+++ b/www/views/tab-settings.html
@@ -20,7 +20,7 @@
         <span translate>Address Book</span>
         <i class="icon bp-arrow-right"></i>
       </a>
-      <a class="item item-icon-left item-icon-right" ng-click="openExternalLink('https://help.bitpay.com', true, 'BitPay Help Center', 'Help and support information is available at the BitPay Help Center website. Would you like to go there now?', 'Open Help Center', 'Go Back')">
+      <a class="item item-icon-left item-icon-right" ng-click="openExternalLink('https://help.bitpay.com/bitpay-app', true, 'BitPay Help Center', 'Help and support information is available at the BitPay Help Center website. Would you like to go there now?', 'Open Help Center', 'Go Back')">
         <i class="icon big-icon-svg">
           <img src="img/icon-help-support.svg" class="bg"/>
         </i>


### PR DESCRIPTION
This updates the Help Center link in the wallet's settings view to point toward the BitPay app category on help.bitpay.com. 