### PR TITLE
Passes back error message from BWC rather than the object.

### DIFF
--- a/src/js/services/walletService.js
+++ b/src/js/services/walletService.js
@@ -144,7 +144,7 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
           if (err instanceof errors.NOT_AUTHORIZED) {
             return cb('WALLET_NOT_REGISTERED');
           }
-          return cb(err);
+          return cb(err.message);
         }
         return cb(null, ret);
       });


### PR DESCRIPTION
This PR needs to be coordinated with an update to BWC error message strings.  The string presented to the UI is coming from BWC error messages, which is ok but those messages are terse and not informative for a user.

Also see https://github.com/bitpay/bitcore-wallet-client/pull/343.