### PR TITLE
Empty send view - refresh

### DIFF
--- a/src/js/controllers/tab-send.js
+++ b/src/js/controllers/tab-send.js
@@ -136,6 +136,7 @@ angular.module('copayApp.controllers').controller('tabSendController', function(
         if (index == wallets.length) $scope.checkingBalance = false;
         if (err || !status) {
           $log.error(err);
+          $scope.$apply();
           return;
         }
 


### PR DESCRIPTION
With a bogus bws: If we wait on home for a while and then go to send, the page remains blank.

Related https://github.com/bitpay/copay/issues/5268