### PR TITLE
fix address text

### DIFF
--- a/src/sass/views/tab-receive.scss
+++ b/src/sass/views/tab-receive.scss
@@ -117,6 +117,7 @@
         transform: translate(-150%, -40%);
       }
       .item {
+        white-space: nowrap;
         padding-top: 5px;
         padding-bottom: 5px;
         font-size: .7rem;


### PR DESCRIPTION
Fixes:

<img width="360" alt="copay_-_copay_bitcoin_wallet" src="https://cloud.githubusercontent.com/assets/13851807/21363513/acb1ab94-c6cb-11e6-948d-3a0de601357c.png">