### PR TITLE
Fix wallet deletion without push

### DIFF
--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -480,10 +480,12 @@ angular.module('copayApp.services')
     root.deleteWalletClient = function(client, cb) {
       var walletId = client.credentials.walletId;
 
-      pushNotificationsService.unsubscribe(root.getWallet(walletId), function(err) {
-        if (err) $log.warn('Unsubscription error: ' + err.message);
-        else $log.debug('Unsubscribed from push notifications service');
-      });
+      var config = configService.getSync();
+      if (config.pushNotifications.enabled)
+        pushNotificationsService.unsubscribe(root.getWallet(walletId), function(err) {
+          if (err) $log.warn('Unsubscription error: ' + err.message);
+          else $log.debug('Unsubscribed from push notifications service');
+        });
 
       $log.debug('Deleting Wallet:', client.credentials.walletName);
       client.removeAllListeners();


### PR DESCRIPTION
Fix a BWS crash when deleting a wallet with push disabled. No need of push unsubscribe when push is disabled. Else this leads to a full crash and stop of BWS server incase it doesn't support push.