### PR TITLE
Fix missing setting icon on iOS

### DIFF
--- a/app-template/config-template.xml
+++ b/app-template/config-template.xml
@@ -91,6 +91,7 @@
       <icon src="resources/*PACKAGENAME*/ios/icon/icon-72@2x.png" width="144" height="144" />
       <icon src="resources/*PACKAGENAME*/ios/icon/icon-small.png" width="29" height="29" />
       <icon src="resources/*PACKAGENAME*/ios/icon/icon-small@2x.png" width="58" height="58" />
+      <icon src="resources/*PACKAGENAME*/ios/icon/icon-small@3x.png" width="87" height="87" />
       <icon src="resources/*PACKAGENAME*/ios/icon/icon-50.png" width="50" height="50" />
       <icon src="resources/*PACKAGENAME*/ios/icon/icon-50@2x.png" width="100" height="100" />
 


### PR DESCRIPTION
fixes #5299 

Device: iPhone 6 plus. (iOS 10.2)