### PR TITLE
Check if have rates

### DIFF
--- a/src/js/controllers/confirm.js
+++ b/src/js/controllers/confirm.js
@@ -857,6 +857,7 @@ angular.module('copayApp.controllers').controller('confirmController', function(
         $log.warn(err);
         return;
       }
+      if (lodash.isEmpty(res)) return;
       if (unitName == 'bits') {
         $scope.exchangeRate = '1,000,000 bits ~ ' + res.rate + ' ' + alternativeIsoCode;
       } else {


### PR DESCRIPTION
* Sometimes if the wallet can't get rates (on top-up process), give a javascript error.