### PR TITLE
Display updated memo on save

### DIFF
--- a/src/js/controllers/tx-details.js
+++ b/src/js/controllers/tx-details.js
@@ -119,6 +119,7 @@ angular.module('copayApp.controllers').controller('txDetailsController', functio
           $log.debug('Could not save tx comment ' + err);
         }
       });
+      $scope.$apply();
     });
   };
 


### PR DESCRIPTION
Updated memo isn't displayed to the user on save on same view. User has to perform some other action such as re-edit or go back, to see the changes reflect. To fix this, added $scope.$apply() to make sure changes are displayed to the user on save.