### PR TITLE
Allow user to cancel on going progress and hide spinner dialog

### DIFF
--- a/src/js/services/onGoingProcess.js
+++ b/src/js/services/onGoingProcess.js
@@ -79,7 +79,7 @@ angular.module('copayApp.services').factory('ongoingProcess', function($log, $ti
       customHandler(processName, showName, isOn);
     } else if (root.onGoingProcessName) {
       if (isCordova) {
-        window.plugins.spinnerDialog.show(null, showName, true);
+        window.plugins.spinnerDialog.show(null, showName, root.clear);
       } else {
 
         var tmpl = '<div class="item-icon-left">' + showName + '<ion-spinner class="spinner-stable" icon="lines"></ion-spinner></div>';


### PR DESCRIPTION
User doesn't have ability to cancel on going progress, thus spinner dialog runs forever. Otherwise, during no network connection, if user goes to view their transaction the spinner dialog will run forever and requires app restart to get back. Set root.clear as callback, so user are able to cancel the progress and hide the spinner dialog.