### PR TITLE
Fix message overflow

### DIFF
--- a/src/sass/views/includes/txp-details.scss
+++ b/src/sass/views/includes/txp-details.scss
@@ -12,7 +12,7 @@
     bottom: 92px;
   }
   .head {
-    padding: 30px $item-lateral-padding 4rem;
+    padding: 30px $item-lateral-padding 3rem;
     border-top: 0;
 
     .sending-label {


### PR DESCRIPTION
For small devices:

<img width="323" alt="copay_-_copay_bitcoin_wallet" src="https://cloud.githubusercontent.com/assets/13851807/22078178/f76f62b2-dd95-11e6-8458-49c82bbe9fae.png">
