### PR TITLE
feat(cordova): add screen privacy for iOS and Android

### DIFF
--- a/app-template/config-template.xml
+++ b/app-template/config-template.xml
@@ -66,6 +66,7 @@
     </plugin>
     <plugin name="cordova-custom-config" spec="~3.0.5" />
     <plugin name="cordova-plugin-queries-schemes" spec="~0.1.5" />
+    <plugin name="cordova-plugin-privacyscreen" spec="~0.3.1" />
 
     <!-- Supported Platforms -->
     <engine name="ios" spec="~4.2.1" />


### PR DESCRIPTION
Tested on iOS and Android.

Works really well on iOS The Android implementation is a bit strange (just leaves the app preview blank), but in testing other apps, it doesn't seem like there's a better way to do it. So this is probably good for now.