### PR TITLE
Allow for wallet colors to be set by css.

### DIFF
--- a/src/js/controllers/preferencesColor.js
+++ b/src/js/controllers/preferencesColor.js
@@ -5,15 +5,15 @@ angular.module('copayApp.controllers').controller('preferencesColorController', 
   $scope.wallet = wallet;
   var walletId = wallet.credentials.walletId;
   var config = configService.getSync();
-  $scope.colorList = configService.getColorList();
   config.colorFor = config.colorFor || {};
-  $scope.currentColor = config.colorFor[walletId] || '#4A90E2';
 
-  $timeout(function() {
-    $scope.$apply();
-  });
+  $scope.colorCount = getColorCount();
+  setCurrentColorIndex();
 
-  $scope.save = function(color) {
+  $scope.save = function(i) {
+    var color = indexToColor(i);
+    if (!color) return;
+
     var opts = {
       colorFor: {}
     };
@@ -24,4 +24,46 @@ angular.module('copayApp.controllers').controller('preferencesColorController', 
       $ionicHistory.goBack();
     });
   };
+
+  function getColorCount() {
+    var count = window.getComputedStyle(document.getElementsByClassName('wallet-color-count')[0]).content;
+    return parseInt(count.replace(/\"/g, ''));
+  };
+
+  function setCurrentColorIndex() {
+    // Wait for DOM to render
+    $timeout(function() {
+      $scope.currentColorIndex = colorToIndex(config.colorFor[walletId] || '#4A90E2');
+      if (!$scope.currentColorIndex) {
+        setCurrentColorIndex();
+      }
+    }, 100);
+  };
+
+  function colorToIndex(color) {
+    for (var i = 0; i < $scope.colorCount; i++) {
+      if (indexToColor(i) == color) {
+        return i;
+      }
+    }
+    return undefined;
+  };
+
+  function indexToColor(i) {
+    function rgb2hex(rgb) {
+      rgb = rgb.match(/^rgba?[\s+]?\([\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?/i);
+      return (rgb && rgb.length === 4) ? "#" +
+        ("0" + parseInt(rgb[1],10).toString(16)).slice(-2) +
+        ("0" + parseInt(rgb[2],10).toString(16)).slice(-2) +
+        ("0" + parseInt(rgb[3],10).toString(16)).slice(-2) : '';
+    };
+    var color;
+    try {
+      color = rgb2hex(window.getComputedStyle(document.getElementsByClassName('wallet-color-' + i)[0]).backgroundColor);
+    } catch(e) {
+      color = undefined;
+    }
+    return color;
+  };
+
 });

--- a/src/js/filters/filters.js
+++ b/src/js/filters/filters.js
@@ -71,4 +71,12 @@ angular.module('copayApp.filters', [])
       if (reverse) filtered.reverse();
       return filtered;
     };
+  })
+  .filter('range', function() {
+    return function(input, total) {
+      total = parseInt(total);
+      for (var i = 0; i < total; i++)
+        input.push(i);
+      return input;
+    };
   });

--- a/src/js/services/configService.js
+++ b/src/js/services/configService.js
@@ -83,69 +83,6 @@ angular.module('copayApp.services').factory('configService', function(storageSer
 
   var configCache = null;
 
-  var colorList = [
-    {
-      color: "#DD4B39",
-      name: "Cinnabar"
-  },
-    {
-      color: "#F38F12",
-      name: "Carrot Orange"
-  },
-    {
-      color: "#FAA77F",
-      name: "Light Salmon"
-  },
-    {
-      color: "#D0B136",
-      name: "Metallic Gold"
-  },
-    {
-      color: "#9EDD72",
-      name: "Feijoa"
-  },
-    {
-      color: "#29BB9C",
-      name: "Shamrock"
-  },
-    {
-      color: "#019477",
-      name: "Observatory"
-  },
-    {
-      color: "#77DADA",
-      name: "Turquoise Blue"
-  },
-    {
-      color: "#4A90E2",
-      name: "Cornflower Blue"
-  },
-    {
-      color: "#484ED3",
-      name: "Free Speech Blue"
-  },
-    {
-      color: "#9B59B6",
-      name: "Deep Lilac"
-  },
-    {
-      color: "#E856EF",
-      name: "Free Speech Magenta"
-  },
-    {
-      color: "#FF599E",
-      name: "Brilliant Rose"
-  },
-    {
-      color: "#7A8C9E",
-      name: "Light Slate Grey"
-  }
-    ];
-
-  root.getColorList = function() {
-    return colorList;
-  };
-
   root.getSync = function() {
     if (!configCache)
       throw new Error('configService#getSync called when cache is not initialized');

--- a/src/sass/colors.scss
+++ b/src/sass/colors.scss
@@ -1,0 +1,34 @@
+/*
+ * Wallet colors
+ */
+
+$wallet-color-map: (
+   0: (color: #DD4B39, name: 'Cinnabar'),
+   1: (color: #F38F12, name: 'Carrot Orange'),
+   2: (color: #FAA77F, name: 'Light Salmon'),
+   3: (color: #D0B136, name: 'Metallic Gold'),
+   4: (color: #9EDD72, name: 'Feijoa'),
+   5: (color: #29BB9C, name: 'Shamrock'),
+   6: (color: #019477, name: 'Observatory'),
+   7: (color: #77DADA, name: 'Turquoise Blue'),
+   8: (color: #4A90E2, name: 'Cornflower Blue'),
+   9: (color: #484ED3, name: 'Free Speech Blue'),
+  10: (color: #9B59B6, name: 'Deep Lilac'),
+  11: (color: #E856EF, name: 'Free Speech Magenta'),
+  12: (color: #FF599E, name: 'Brilliant Rose'),
+  13: (color: #7A8C9E, name: 'Light Slate Grey')
+);
+
+.wallet-color-count {
+  content: '14';
+}
+
+@each $id, $map in $wallet-color-map {
+  .wallet-color-#{$id} {
+    background: map-get($map, color);
+  }
+  .wallet-color-#{$id}:before {
+    content: map-get($map, name);
+    margin-left: 2.4rem;
+  }
+}

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -1,3 +1,4 @@
+@import "colors";
 @import "fonts";
 @import "variables";
 @import "ionic";

--- a/www/views/preferencesColor.html
+++ b/www/views/preferencesColor.html
@@ -6,10 +6,9 @@
     <ion-nav-back-button>
     </ion-nav-back-button>
   </ion-nav-bar>
-  <ion-content>
-    <ion-radio ng-repeat="c in colorList" ng-value="c.color" ng-model="currentColor" ng-click="save(c.color)">
-      <span ng-style="{'background-color': c.color, 'color' : c.color}" class="settings-color-block"></span>
-      <span class="settings-color-name"> {{c.name}}</span>
+  <ion-content class="wallet-color-count">
+    <ion-radio ng-repeat="i in [] | range:colorCount" ng-value="i" ng-model="currentColorIndex" ng-click="save(i)">
+      <span class="settings-color-block wallet-color-{{i}}"></span>
     </ion-radio>
   </ion-content>
 </ion-view>


### PR DESCRIPTION
This change moves the definitions of wallet colors from javascript to css making it very easy to define a distinct and arbitrary set of wallet colors for copay vs. bitpay apps via css changes only.