### PR TITLE
Bug/empty app after refresh

### DIFF
--- a/src/js/controllers/walletDetails.js
+++ b/src/js/controllers/walletDetails.js
@@ -340,6 +340,7 @@ angular.module('copayApp.controllers').controller('walletDetailsController', fun
   $scope.$on("$ionicView.beforeEnter", function(event, data) {
     $scope.walletId = data.stateParams.walletId;
     $scope.wallet = profileService.getWallet($scope.walletId);
+    if (!$scope.wallet) return;
     $scope.requiresMultipleSignatures = $scope.wallet.credentials.m > 1;
 
     addressbookService.list(function(err, ab) {

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -1177,7 +1177,16 @@ angular.module('copayApp').config(function(historicLogProvider, $provide, $logPr
           profileService.storeProfileIfDirty();
           $log.debug('Profile loaded ... Starting UX.');
           scannerService.gentleInitialize();
-          $state.go('tabs.home');
+          // Reload tab-home if necessary (from root path: starting)
+          $state.go('starting', {}, {
+            'reload': true,
+            'notify': $state.current.name == 'starting' ? false : true
+          }).then(function() {
+            $ionicHistory.nextViewOptions({
+              disableAnimate: true
+            });
+            $state.transitionTo('tabs.home');
+          });
         }
 
         // After everything have been loaded, initialize handler URL

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -1183,9 +1183,13 @@ angular.module('copayApp').config(function(historicLogProvider, $provide, $logPr
             'notify': $state.current.name == 'starting' ? false : true
           }).then(function() {
             $ionicHistory.nextViewOptions({
-              disableAnimate: true
+              disableAnimate: true,
+              historyRoot: true
             });
-            $state.transitionTo('tabs.home');
+            $state.transitionTo('tabs.home').then(function() {
+              // Clear history
+              $ionicHistory.clearHistory();
+            });
           });
         }
 


### PR DESCRIPTION
Fixes #5635

*Issue*: after a hard refresh or resume, sometimes the app appears to be empty, no wallets, no external services on the first view (tab-home). It could be fixed manually changing to another tab and back tab-home.

*Solution*: this PR force the app to restart from the "starting" view. If this view has already been loaded, do nothing, just go to tab-home automatically.