### PR TITLE
temporary fix for the tabs confusion

### DIFF
--- a/www/views/walletDetails.html
+++ b/www/views/walletDetails.html
@@ -1,4 +1,4 @@
-<ion-view id="walletDetails">
+<ion-view id="walletDetails" hide-tabs>
 
   <ion-nav-bar ng-class="{'wallet-background-color-default': !wallet.color}" ng-style="{'background-color': wallet.color}">
     <ion-nav-title>{{wallet.name}}</ion-nav-title>
@@ -103,7 +103,7 @@
       <div
         ng-style="{'background-color':wallet.color}"
         class="amount"
-        ng-class="{'collapsible': amountIsCollapsible, 'wallet-background-color-default': !wallet.color}" 
+        ng-class="{'collapsible': amountIsCollapsible, 'wallet-background-color-default': !wallet.color}"
       >
         <div ng-if="!updatingStatus">
 


### PR DESCRIPTION
This is a temporary fix to avoid the users to copy a wrong address when they enter to the wallet details of a wallet and then enter to the receive tab.

Confusion: 
```
So I click on the wallet in the home screen
Then I click on "Receive" at the bottom
It shows me an address. But this is the address for a TOTALLY DIFFERENT WALLET.
```