### PR TITLE
fix bug when changing selector too fast

### DIFF
--- a/src/js/directives/directives.js
+++ b/src/js/directives/directives.js
@@ -157,7 +157,7 @@ angular.module('copayApp.directives')
           scope.$emit('Wallet/Changed', scope.wallets ? scope.wallets[0] : null);
         });
 
-        scope.$on("$ionicSlides.slideChangeEnd", function(event, data) {
+        scope.$on("$ionicSlides.slideChangeStart", function(event, data) {
           scope.$emit('Wallet/Changed', scope.wallets ? scope.wallets[data.slider.activeIndex] : null);
         });
       }


### PR DESCRIPTION
When you change the slider to fast the slideChangeEnd event is not fired, so, you get a wrong address. 