### PR TITLE
Problem opening Copay on Android from another Cordova app

### DIFF
--- a/app-template/config-template.xml
+++ b/app-template/config-template.xml
@@ -11,7 +11,7 @@
         BitPay Inc.
     </author>
     <content src="index.html" />
-    <access launch-external="yes" origin="*" />
+    <access origin="*" />
     <preference name="AndroidLaunchMode" value="singleTask" />
     <preference name="AndroidPersistentFileLocation" value="Internal" />
     <preference name="iosPersistentFileLocation" value="Library" />

--- a/app-template/config-template.xml
+++ b/app-template/config-template.xml
@@ -11,7 +11,8 @@
         BitPay Inc.
     </author>
     <content src="index.html" />
-    <access origin="*" />
+    <access launch-external="yes" origin="*" />
+    <preference name="AndroidLaunchMode" value="singleTask" />
     <preference name="AndroidPersistentFileLocation" value="Internal" />
     <preference name="iosPersistentFileLocation" value="Library" />
     <preference name="DisallowOverscroll" value="true"/>


### PR DESCRIPTION
Hello,

We've noticed a problem opening Copay on Android from another Cordova app 
when using bitpay/cordova-sdk. Copay is opened within the same window as the calling app, 
making hard to switch back to the calling app. The similar problem is described at
https://stackoverflow.com/questions/28058633/deep-linking-into-a-cordova-app-from-a-web-browser-on-android-opens-app-within-t

Regards, Egor