### PR TITLE
Unifies card history view with wallet view

### DIFF
--- a/src/js/controllers/bitpayCard.js
+++ b/src/js/controllers/bitpayCard.js
@@ -163,7 +163,7 @@ angular.module('copayApp.controllers').controller('bitpayCardController', functi
     runningBalance -= parseFloat(tx.amount);
   };
 
-  this.withinPastDay = function(tx) {
+  $scope.createdWithinPastDay = function(tx) {
     var result = false;
     if (tx.timestamp) {
       result = timeService.withinPastDay(tx.timestamp);

--- a/src/js/controllers/bitpayCard.js
+++ b/src/js/controllers/bitpayCard.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('copayApp.controllers').controller('bitpayCardController', function($scope, $timeout, $log, $state, lodash, bitpayCardService, moment, popupService, gettextCatalog, $ionicHistory, bitpayService, externalLinkService) {
+angular.module('copayApp.controllers').controller('bitpayCardController', function($scope, $timeout, $log, $state, lodash, bitpayCardService, moment, popupService, gettextCatalog, $ionicHistory, bitpayService, externalLinkService, timeService) {
 
   var self = this;
   var runningBalance;
@@ -161,6 +161,14 @@ angular.module('copayApp.controllers').controller('bitpayCardController', functi
 
   var _runningBalance = function(tx) {
     runningBalance -= parseFloat(tx.amount);
+  };
+
+  this.withinPastDay = function(tx) {
+    var result = false;
+    if (tx.timestamp) {
+      result = timeService.withinPastDay(tx.timestamp);
+    }
+    return result;
   };
 
   this.openExternalLink = function(url) {

--- a/src/js/controllers/proposals.js
+++ b/src/js/controllers/proposals.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('copayApp.controllers').controller('proposalsController',
-  function($timeout, $scope, profileService, $log, txpModalService, addressbookService) {
+  function($timeout, $scope, profileService, $log, txpModalService, addressbookService, timeService) {
 
     $scope.fetchingProposals = true;
 
@@ -27,8 +27,6 @@ angular.module('copayApp.controllers').controller('proposalsController',
     $scope.openTxpModal = txpModalService.open;
 
     $scope.createdWithinPastDay = function(time) {
-      var now = new Date();
-      var date = new Date(time * 1000);
-      return (now.getTime() - date.getTime()) < (1000 * 60 * 60 * 24);
+      return timeService.withinPastDay(time);
     };
   });

--- a/src/js/controllers/tab-home.js
+++ b/src/js/controllers/tab-home.js
@@ -131,9 +131,7 @@ angular.module('copayApp.controllers').controller('tabHomeController',
     });
 
     $scope.createdWithinPastDay = function(time) {
-      var now = new Date();
-      var date = new Date(time * 1000);
-      return (now.getTime() - date.getTime()) < (1000 * 60 * 60 * 24);
+      return timeService.withinPastDay(time);
     };
 
     $scope.openExternalLink = function() {

--- a/src/js/controllers/tab-home.js
+++ b/src/js/controllers/tab-home.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('copayApp.controllers').controller('tabHomeController',
-  function($rootScope, $timeout, $scope, $state, $stateParams, $ionicModal, $ionicScrollDelegate, $window, gettextCatalog, lodash, popupService, ongoingProcess, externalLinkService, latestReleaseService, profileService, walletService, configService, $log, platformInfo, storageService, txpModalService, appConfigService, startupService, addressbookService, feedbackService, bwcError, nextStepsService, buyAndSellService, homeIntegrationsService, bitpayCardService, pushNotificationsService) {
+  function($rootScope, $timeout, $scope, $state, $stateParams, $ionicModal, $ionicScrollDelegate, $window, gettextCatalog, lodash, popupService, ongoingProcess, externalLinkService, latestReleaseService, profileService, walletService, configService, $log, platformInfo, storageService, txpModalService, appConfigService, startupService, addressbookService, feedbackService, bwcError, nextStepsService, buyAndSellService, homeIntegrationsService, bitpayCardService, pushNotificationsService, timeService) {
     var wallet;
     var listeners = [];
     var notifications = [];

--- a/src/js/controllers/walletDetails.js
+++ b/src/js/controllers/walletDetails.js
@@ -190,7 +190,7 @@ angular.module('copayApp.controllers').controller('walletDetailsController', fun
     }
     var curTx = $scope.txHistory[index];
     var prevTx = $scope.txHistory[index - 1];
-    return !createdDuringSameMonth(curTx, prevTx);
+    return !$scope.createdDuringSameMonth(curTx, prevTx);
   };
 
   $scope.isLastInGroup = function(index) {

--- a/src/js/controllers/walletDetails.js
+++ b/src/js/controllers/walletDetails.js
@@ -201,7 +201,7 @@ angular.module('copayApp.controllers').controller('walletDetailsController', fun
   };
 
   $scope.createdDuringSameMonth = function(curTx, prevTx) {
-    return timeService.withinSameMonth(curTx.time, prevTx.time);
+    return timeService.withinSameMonth(curTx.time * 1000, prevTx.time * 1000);
   };
 
   $scope.createdWithinPastDay = function(time) {

--- a/src/js/controllers/walletDetails.js
+++ b/src/js/controllers/walletDetails.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('copayApp.controllers').controller('walletDetailsController', function($scope, $rootScope, $interval, $timeout, $filter, $log, $ionicModal, $ionicPopover, $state, $stateParams, $ionicHistory, profileService, lodash, configService, platformInfo, walletService, txpModalService, externalLinkService, popupService, addressbookService, storageService, $ionicScrollDelegate, $window, bwcError, gettextCatalog) {
+angular.module('copayApp.controllers').controller('walletDetailsController', function($scope, $rootScope, $interval, $timeout, $filter, $log, $ionicModal, $ionicPopover, $state, $stateParams, $ionicHistory, profileService, lodash, configService, platformInfo, walletService, txpModalService, externalLinkService, popupService, addressbookService, storageService, $ionicScrollDelegate, $window, bwcError, gettextCatalog, timeService) {
 
   var HISTORY_SHOW_LIMIT = 10;
   var currentTxHistoryPage = 0;
@@ -200,27 +200,17 @@ angular.module('copayApp.controllers').controller('walletDetailsController', fun
     return $scope.isFirstInGroup(index + 1);
   };
 
-  function createdDuringSameMonth(tx1, tx2) {
-    if (!tx1 || !tx2) return false;
-    var date1 = new Date(tx1.time * 1000);
-    var date2 = new Date(tx2.time * 1000);
-    return getMonthYear(date1) === getMonthYear(date2);
-  }
+  $scope.createdDuringSameMonth = function(curTx, prevTx) {
+    return timeService.withinSameMonth(curTx.time, prevTx.time);
+  };
 
   $scope.createdWithinPastDay = function(time) {
-    var now = new Date();
-    var date = new Date(time * 1000);
-    return (now.getTime() - date.getTime()) < (1000 * 60 * 60 * 24);
+    return timeService.withinPastDay(time);
   };
 
   $scope.isDateInCurrentMonth = function(date) {
-    var now = new Date();
-    return getMonthYear(now) === getMonthYear(date);
+    return timeService.isDateInCurrentMonth(date);
   };
-
-  function getMonthYear(date) {
-    return date.getMonth() + date.getFullYear();
-  }
 
   $scope.isUnconfirmed = function(tx) {
     return !tx.confirmations || tx.confirmations === 0;

--- a/src/js/directives/svg.js
+++ b/src/js/directives/svg.js
@@ -10,7 +10,7 @@ angular.module('copayApp.directives')
       link: function(scope, element, attrs) {
         var imgId = attrs.id;
         var imgClass = attrs.class;
-        var imgUrl = attrs.src;
+        var imgUrl = attrs.src || attrs.ngSrc;
         var svg;
 
         // Load svg content

--- a/src/js/services/bitpayCardService.js
+++ b/src/js/services/bitpayCardService.js
@@ -65,6 +65,7 @@ angular.module('copayApp.services').factory('bitpayCardService', function($log, 
         n.lastFourDigits = x.lastFourDigits;
         n.token = x.token;
         n.currency = x.currency;
+        n.country = x.country;
         cards.push(n);
       });
 

--- a/src/js/services/timeService.js
+++ b/src/js/services/timeService.js
@@ -5,20 +5,20 @@ angular.module('copayApp.services').factory('timeService', function() {
 
   root.withinSameMonth = function(time1, time2) {
     if (!time1 || !time2) return false;
-    var date1 = new Date(time1 * 1000);
-    var date2 = new Date(time2 * 1000);
-    return getMonthYear(date1) === getMonthYear(date2);
+    var date1 = new Date(time1);
+    var date2 = new Date(time2);
+    return root.getMonthYear(date1) === root.getMonthYear(date2);
   }
 
   root.withinPastDay = function(time) {
     var now = new Date();
-    var date = new Date(time * 1000);
+    var date = new Date(time);
     return (now.getTime() - date.getTime()) < (1000 * 60 * 60 * 24);
   };
 
   root.isDateInCurrentMonth = function(date) {
     var now = new Date();
-    return getMonthYear(now) === getMonthYear(date);
+    return root.getMonthYear(now) === root.getMonthYear(date);
   };
 
   root.getMonthYear = function(date) {

--- a/src/js/services/timeService.js
+++ b/src/js/services/timeService.js
@@ -1,0 +1,30 @@
+'use strict';
+
+angular.module('copayApp.services').factory('timeService', function() {
+  var root = {};
+
+  root.withinSameMonth = function(time1, time2) {
+    if (!time1 || !time2) return false;
+    var date1 = new Date(time1 * 1000);
+    var date2 = new Date(time2 * 1000);
+    return getMonthYear(date1) === getMonthYear(date2);
+  }
+
+  root.withinPastDay = function(time) {
+    var now = new Date();
+    var date = new Date(time * 1000);
+    return (now.getTime() - date.getTime()) < (1000 * 60 * 60 * 24);
+  };
+
+  root.isDateInCurrentMonth = function(date) {
+    var now = new Date();
+    return getMonthYear(now) === getMonthYear(date);
+  };
+
+  root.getMonthYear = function(date) {
+    return date.getMonth() + date.getFullYear();
+  }
+
+  return root;
+
+});

--- a/src/sass/views/bitpayCard.scss
+++ b/src/sass/views/bitpayCard.scss
@@ -70,7 +70,65 @@
     }
   }
   .item {
-    border-color: $item-border-color;
+    display: flex;
+    align-items: center;
+    background: #fff;
+    padding: 0 0 0 1rem;
+    margin: 0;
+    border: 0;
+
+    &.send .svg #-Transaction-icons {
+    }
+    &.receive .svg #-Transaction-icons {
+      stroke: #09C286;
+    }
+    &.pending .svg #-Transaction-icons {
+      stroke: $v-bitcoin-orange;
+    }
+  }
+  .tx-icon {
+    float: left;
+    margin-right: 25px;
+  }
+  .tx-content {
+    display: flex;
+    align-items: center;
+    flex-grow: 1;
+    padding: 1rem 0;
+    padding-right: 1rem;
+    border-bottom: 1px solid rgb(245, 245, 245);
+    overflow: hidden;
+  }
+  .tx-title {
+    flex-grow: 1;
+    color: $v-dark-gray;
+    overflow: hidden;
+  }
+  .tx-message {
+    margin-right: 1rem;
+  }
+  .tx-location {
+    margin-right: 1rem;
+    font-size: 12.5px;
+    color: $v-light-gray;
+  }
+  .tx-amount {
+    font-size: 16px;
+    white-space: nowrap;
+    &--received {
+      color: #09C286;
+    }
+    &--sent {
+      color: $v-dark-gray;
+    }
+    &--pending {
+      color: $v-bitcoin-orange;
+    }
+  }
+  .tx-time {
+    white-space: nowrap;
+    color: $v-light-gray;
+    font-size: 12.5px;
   }
   .info {
     .badge {

--- a/src/sass/views/bitpayCard.scss
+++ b/src/sass/views/bitpayCard.scss
@@ -95,10 +95,36 @@
     }
   }
   .tx-icon {
-    width: 36px;
-    height: 36px;
-    float: left;
     margin-right: 25px;
+    .houston {
+      width: 40px;
+      height: 40px;
+      border-radius: 40px;
+      border: 1px solid;
+      &.no-border {
+        border: none;
+        .svg {
+          width: 40px;
+          height: 40px;
+          display: block;
+          margin: 0 auto;
+          position: relative;
+          top: 50%;
+          -webkit-transform: translateY(-50%);
+          transform: translateY(-50%);
+        }
+      }
+      .svg {
+        width: 23px;
+        height: 23px;
+        display: block;
+        margin: 0 auto;
+        position: relative;
+        top: 50%;
+        -webkit-transform: translateY(-50%);
+        transform: translateY(-50%);
+      }
+    }
   }
   .tx-content {
     display: flex;

--- a/src/sass/views/bitpayCard.scss
+++ b/src/sass/views/bitpayCard.scss
@@ -70,23 +70,33 @@
     }
   }
   .item {
-    display: flex;
-    align-items: center;
-    background: #fff;
-    padding: 0 0 0 1rem;
-    margin: 0;
-    border: 0;
+    border-color: $item-border-color;
+    &.activity-header {
+      z-index: 3;
+      border: 0;
+      border-bottom: 1px solid #EFEFEF;
+    }
+    &.activity {
+      display: flex;
+      align-items: center;
+      background: #fff;
+      padding: 0 0 0 1rem;
+      margin: 0;
+      border: 0;
 
-    &.send .svg #-Transaction-icons {
-    }
-    &.receive .svg #-Transaction-icons {
-      stroke: #09C286;
-    }
-    &.pending .svg #-Transaction-icons {
-      stroke: $v-bitcoin-orange;
+      &.send .svg #-Transaction-icons {
+      }
+      &.receive .svg #-Transaction-icons {
+        stroke: #09C286;
+      }
+      &.pending .svg #-Transaction-icons {
+        stroke: $v-bitcoin-orange;
+      }
     }
   }
   .tx-icon {
+    width: 36px;
+    height: 36px;
     float: left;
     margin-right: 25px;
   }

--- a/www/views/bitpayCard.html
+++ b/www/views/bitpayCard.html
@@ -64,7 +64,7 @@
       <a ng-click="bitpayCard.openExternalLink('https://help.bitpay.com/bitpay-card/why-was-i-overcharged-on-my-bitpay-card-account-why-is-there-a-hold-on-my-account')" translate>Learn More</a>
     </div>
     <div class="list" ng-show="!bitpayCard.getStarted">
-      <label class="item item-input item-select">
+      <label class="item item-input item-select activity-header">
         <div class="input-label" translate>
           Activity
         </div>

--- a/www/views/includes/cardActivity.html
+++ b/www/views/includes/cardActivity.html
@@ -1,5 +1,5 @@
-<div class="item" ng-class="{'sent': tx.price.toString().indexOf('-') > -1 && !tx.pending, 'receive': tx.price.toString().indexOf('-') == -1 && !tx.pending, 'pending': tx.pending}">
-  <img class="tx-icon svg" ng-src="img/mcc-icons/{{tx.icon}}.svg" width="40">
+<div class="item activity" ng-class="{'sent': tx.price.toString().indexOf('-') > -1 && !tx.pending, 'receive': tx.price.toString().indexOf('-') == -1 && !tx.pending, 'pending': tx.pending}">
+  <img class="tx-icon svg" ng-src="img/mcc-icons/{{tx.icon}}.svg">
   <div class="tx-content">
     <div class="tx-title">
       <div class="ellipsis">

--- a/www/views/includes/cardActivity.html
+++ b/www/views/includes/cardActivity.html
@@ -1,43 +1,23 @@
-<div class="item row">
-  <div class="col col-10 text-center">
-    <div class="tu size-10">{{tx.timestamp | amDateFormat:'MMM'}}</div>
-    <div class="text-light">{{tx.timestamp | amDateFormat:'DD'}}</div>
-  </div>
-  <div class="col col-10">
-    <img class="m15t" ng-src="img/mcc-icons/{{tx.icon}}.svg" width="24">
-  </div>
-
-  <div class="col col-50">
-    <div class="size-12 text-bold">
-      {{tx.merchant.name || 'Unknown Merchant'}}
+<div class="item" ng-class="{'sent': tx.price.toString().indexOf('-') > -1 && !tx.pending, 'receive': tx.price.toString().indexOf('-') == -1 && !tx.pending, 'pending': tx.pending}">
+  <img class="tx-icon svg" ng-src="img/mcc-icons/{{tx.icon}}.svg" width="40">
+  <div class="tx-content">
+    <div class="tx-title">
+      <div class="ellipsis">
+        <div class="tx-message ellipsis">{{tx.merchant.name || 'Unknown Merchant'}}</div>
+        <div class="tx-location ellipsis" ng-show="tx.merchant.city && tx.merchant.state">{{tx.merchant.location}}</div>
+        <div ng-show="tx.pending && tx.transactionId" class="size-12 tx-amount--pending">
+          <div ng-click="bitpayCard.viewOnBlockchain(tx.transactionId)">View Confirmation Status</div>
+        </div>
+      </div>
     </div>
-    <div class="size-12 text-gray">
-      <span ng-show="tx.merchant.city && tx.merchant.state">{{tx.merchant.location}}</span>
-      <span ng-class="{'m5l':tx.merchant.city && tx.merchant.state}">
-        {{tx.timestamp | amDateFormat:'h:mm A'}}
+    <span class="item-note text-right">
+      <span class="tx-amount" ng-class="{'tx-amount--sent': tx.price.toString().indexOf('-') > -1 && !tx.pending, 'tx-amount--received': tx.price.toString().indexOf('-') == -1 && !tx.pending, 'tx-amount--pending': tx.pending}">
+        {{tx.price | currency:bitpayCard.currencySymbol:2 }}
       </span>
-    </div>
-    <div ng-show="tx.pending && tx.transactionId" class="size-12">
-      <a ng-click="bitpayCard.viewOnBlockchain(tx.transactionId)">View Confirmation Status</a>
-    </div>
-  </div>
-
-  <!-- <div class="col size-12">
-    {{tx.desc}}
-  </div>
-  <div class="col col-10 text-center p10t">
-    <img ng-show="!tx.pending" ng-src="img/check.svg" width="14">
-    <img ng-show="tx.pending" ng-src="img/sync.svg" width="14">
-  </div> -->
-
-  <div class="col text-right">
-    <div ng-class="{
-         'balanced': tx.price.toString().indexOf('-') == -1 && !tx.pending,
-         'text-gray': tx.price.toString().indexOf('-') == -1 && tx.pending}">
-      <span ng-show="tx.price.toString().indexOf('-') == -1">+ </span>
-      {{tx.price | currency:bitpayCard.currencySymbol:2 }}
-    </div>
-    <time class="size-12 text-gray" ng-if="!tx.pending">{{tx.runningBalance | currency:bitpayCard.currencySymbol:2}}</time>
-    <span class="size-12 text-gray text-italic" ng-if="tx.pending" class="tu" translate>Pending</span>
+      <div>
+        <time class="tx-time" ng-if="createdWithinPastDay(tx)">{{tx.timestamp | amTimeAgo}}</time>
+        <time class="tx-time" ng-if="!createdWithinPastDay(tx)">{{tx.timestamp | amDateFormat:'MMM D, YYYY'}}</time>
+      </div>
+    </span>
   </div>
 </div>

--- a/www/views/includes/cardActivity.html
+++ b/www/views/includes/cardActivity.html
@@ -1,10 +1,16 @@
 <div class="item activity" ng-class="{'sent': tx.price.toString().indexOf('-') > -1 && !tx.pending, 'receive': tx.price.toString().indexOf('-') == -1 && !tx.pending, 'pending': tx.pending}">
-  <img class="tx-icon svg" ng-src="img/mcc-icons/{{tx.icon}}.svg">
+  <div class="tx-icon">
+    <div class="houston" ng-class="{'no-border': tx.icon.includes('topup')}">
+      <img class="svg" ng-src="img/mcc-icons/{{tx.icon}}.svg">
+    </div>
+  </div>
   <div class="tx-content">
     <div class="tx-title">
       <div class="ellipsis">
         <div class="tx-message ellipsis">{{tx.merchant.name || 'Unknown Merchant'}}</div>
+<!-- Removed to cleanup look and since intl card does not provide location.
         <div class="tx-location ellipsis" ng-show="tx.merchant.city && tx.merchant.state">{{tx.merchant.location}}</div>
+-->
         <div ng-show="tx.pending && tx.transactionId" class="size-12 tx-amount--pending">
           <div ng-click="bitpayCard.viewOnBlockchain(tx.transactionId)">View Confirmation Status</div>
         </div>

--- a/www/views/includes/txp.html
+++ b/www/views/includes/txp.html
@@ -28,8 +28,8 @@
       </span>
     </span>
     <div>
-      <time class="wallet-details__tx-time" ng-if="tx.createdOn && createdWithinPastDay(tx.createdOn)">{{tx.createdOn * 1000 | amTimeAgo}}</time>
-      <time class="wallet-details__tx-time" ng-if="tx.createdOn && !createdWithinPastDay(tx.createdOn)">{{tx.createdOn * 1000 | date:'MMMM d, y'}}</time>
+      <time class="wallet-details__tx-time" ng-if="tx.createdOn && createdWithinPastDay(tx.createdOn * 1000)">{{tx.createdOn * 1000 | amTimeAgo}}</time>
+      <time class="wallet-details__tx-time" ng-if="tx.createdOn && !createdWithinPastDay(tx.createdOn * 1000)">{{tx.createdOn * 1000 | date:'MMMM d, y'}}</time>
     </div>
   </span>
 </div>

--- a/www/views/includes/walletHistory.html
+++ b/www/views/includes/walletHistory.html
@@ -64,8 +64,8 @@
         </span>
       </span>
       <div>
-        <time class="wallet-details__tx-time" ng-if="btx.time && createdWithinPastDay(btx.time)">{{btx.time * 1000 | amTimeAgo}}</time>
-        <time class="wallet-details__tx-time" ng-if="btx.time && !createdWithinPastDay(btx.time)">
+        <time class="wallet-details__tx-time" ng-if="btx.time && createdWithinPastDay(btx.time * 1000)">{{btx.time * 1000 | amTimeAgo}}</time>
+        <time class="wallet-details__tx-time" ng-if="btx.time && !createdWithinPastDay(btx.time * 1000)">
           {{btx.time * 1000 | amDateFormat:'MMM D, YYYY'}}
         </time>
       </div>


### PR DESCRIPTION
- Makes the card history view look the same (similar) to the wallet history view.
- Relative or absolute tx time (less than a day = relative).
- Removes the running balance presentation (UI change only, logic still in place).
- Introduces timeService to share common functions between wallet and card views.
- Enhances svg directive to work with images using ngSrc.
- Adds card `country` to the cards collection (not used at the moment, will need for future policy statements in the app).

![screen shot 2017-06-07 at 6 54 43 pm](https://user-images.githubusercontent.com/1063765/26905194-f5801e06-4bb3-11e7-8752-57f8462e5c48.png)
