### PR TITLE
cashaddr support

### DIFF
--- a/app-template/package-template.json
+++ b/app-template/package-template.json
@@ -56,7 +56,7 @@
     "bezier-easing": "^2.0.3",
     "bhttp": "1.2.1",
     "bitauth": "^0.2.1",
-    "bitcore-wallet-client": "6.4.0",
+    "bitcore-wallet-client": "6.5.0",
     "bower": "^1.8.2",
     "cordova-ios": "4.5.3",
     "cordova-android": "6.4.0",

--- a/src/js/controllers/advancedSettings.js
+++ b/src/js/controllers/advancedSettings.js
@@ -15,6 +15,9 @@ angular.module('copayApp.controllers').controller('advancedSettingsController', 
       value: config.hideNextSteps.enabled
     };
 
+    $scope.useLegacyAddress = {
+      value: config.wallet.useLegacyAddress
+    };
   };
 
   $scope.spendUnconfirmedChange = function() {
@@ -49,6 +52,19 @@ angular.module('copayApp.controllers').controller('advancedSettingsController', 
       if (err) $log.debug(err);
     });
   };
+
+$scope.useLegacyAddressChange = function() {
+    var opts = {
+      wallet: {
+        useLegacyAddress: $scope.useLegacyAddress.value
+      }
+    };
+    configService.set(opts, function(err) {
+      if (err) $log.debug(err);
+    });
+  };
+
+
 
   $scope.$on("$ionicView.beforeEnter", function(event, data) {
     $scope.isWindowsPhoneApp = platformInfo.isCordova && platformInfo.isWP;

--- a/src/js/controllers/confirm.js
+++ b/src/js/controllers/confirm.js
@@ -170,8 +170,14 @@ angular.module('copayApp.controllers').controller('confirmController', function(
       coin: data.stateParams.coin,
       txp: {},
     };
+    tx.origToAddress = tx.toAddress;
 
-    if (tx.coin && tx.coin == 'bch') tx.feeLevel = 'normal';
+    if (tx.coin && tx.coin == 'bch') {
+      tx.feeLevel = 'normal';
+
+      // Use legacy address
+      tx.toAddress = new bitcoreCash.Address(tx.toAddress).toString();
+    };
 
     // Other Scope vars
     $scope.isCordova = isCordova;

--- a/src/js/controllers/customAmount.js
+++ b/src/js/controllers/customAmount.js
@@ -32,7 +32,8 @@ angular.module('copayApp.controllers').controller('customAmountController', func
         return;
       }
 
-      $scope.address = addr;
+      $scope.address = walletService.getAddressView($scope.wallet, addr);
+      $scope.protoAddr = $scope.protocolHandler? $scope.protocolHandler + ':' + $scope.address : $scope.address;
 
       $scope.coin = data.stateParams.coin;
       var parsedAmount = txFormatService.parseAmount(

--- a/src/js/controllers/customAmount.js
+++ b/src/js/controllers/customAmount.js
@@ -33,7 +33,7 @@ angular.module('copayApp.controllers').controller('customAmountController', func
       }
 
       $scope.address = walletService.getAddressView($scope.wallet, addr);
-      $scope.protoAddr = $scope.protocolHandler? $scope.protocolHandler + ':' + $scope.address : $scope.address;
+      $scope.protoAddr = $scope.protocolHandler + ':' + $scope.address;
 
       $scope.coin = data.stateParams.coin;
       var parsedAmount = txFormatService.parseAmount(

--- a/src/js/controllers/tab-receive.js
+++ b/src/js/controllers/tab-receive.js
@@ -25,14 +25,8 @@ angular.module('copayApp.controllers').controller('tabReceiveController', functi
         popupService.showAlert(err);
       }
 
-      if ($scope.wallet.coin == 'bch' && 1) { // todo config
-
-        var a = bitcoreCash.Address(addr);
-        addr = a.toCashAddress();
-      };
-
-      $scope.addr = addr;
-      $scope.protoAddr = $scope.protocolHandler? $scope.protocolHandler + ':' + addr : addr;
+      $scope.addr = walletService.getAddressView($scope.wallet, addr);
+      $scope.protoAddr = $scope.protocolHandler? $scope.protocolHandler + ':' + $scope.addr : $scope.addr;
       $timeout(function() {
         $scope.$apply();
       }, 10);

--- a/src/js/controllers/tab-receive.js
+++ b/src/js/controllers/tab-receive.js
@@ -26,7 +26,7 @@ angular.module('copayApp.controllers').controller('tabReceiveController', functi
       }
 
       $scope.addr = walletService.getAddressView($scope.wallet, addr);
-      $scope.protoAddr = $scope.protocolHandler? $scope.protocolHandler + ':' + $scope.addr : $scope.addr;
+      $scope.protoAddr = ($scope.protocolHandler + ':' + $scope.addr).toUpperCase() ;
       $timeout(function() {
         $scope.$apply();
       }, 10);

--- a/src/js/controllers/tab-receive.js
+++ b/src/js/controllers/tab-receive.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('copayApp.controllers').controller('tabReceiveController', function($rootScope, $scope, $timeout, $log, $ionicModal, $state, $ionicHistory, $ionicPopover, storageService, platformInfo, walletService, profileService, configService, lodash, gettextCatalog, popupService, bwcError) {
+angular.module('copayApp.controllers').controller('tabReceiveController', function($rootScope, $scope, $timeout, $log, $ionicModal, $state, $ionicHistory, $ionicPopover, storageService, platformInfo, walletService, profileService, configService, lodash, gettextCatalog, popupService, bwcError, bitcoreCash) {
 
   var listeners = [];
   $scope.isCordova = platformInfo.isCordova;
@@ -25,7 +25,14 @@ angular.module('copayApp.controllers').controller('tabReceiveController', functi
         popupService.showAlert(err);
       }
 
+      if ($scope.wallet.coin == 'bch' && 1) { // todo config
+
+        var a = bitcoreCash.Address(addr);
+        addr = a.toCashAddress();
+      };
+
       $scope.addr = addr;
+      $scope.protoAddr = $scope.protocolHandler? $scope.protocolHandler + ':' + addr : addr;
       $timeout(function() {
         $scope.$apply();
       }, 10);

--- a/src/js/directives/incomingDataMenu.js
+++ b/src/js/directives/incomingDataMenu.js
@@ -10,6 +10,7 @@ angular.module('copayApp.directives')
           $timeout(function() {
             scope.data = data.data;
             scope.type = data.type;
+            scope.coin = data.coin;
             scope.showMenu = true;
             scope.https = false;
 
@@ -27,12 +28,13 @@ angular.module('copayApp.directives')
         scope.goToUrl = function(url) {
           externalLinkService.open(url);
         };
-        scope.sendPaymentToAddress = function(bitcoinAddress) {
+        scope.sendPaymentToAddress = function(bitcoinAddress, coin) {
           scope.showMenu = false;
           $state.go('tabs.send').then(function() {
             $timeout(function() {
               $state.transitionTo('tabs.send.amount', {
-                toAddress: bitcoinAddress
+                toAddress: bitcoinAddress,
+                coin: coin || 'btc',
               });
             }, 50);
           });

--- a/src/js/services/incomingData.js
+++ b/src/js/services/incomingData.js
@@ -88,6 +88,7 @@ angular.module('copayApp.services').factory('incomingData', function($log, $stat
 
     // Bitcoin  URL
     if (bitcore.URI.isValid(data)) {
+
         var coin = 'btc';
         var parsed = new bitcore.URI(data);
 
@@ -113,6 +114,12 @@ angular.module('copayApp.services').factory('incomingData', function($log, $stat
         var parsed = new bitcoreCash.URI(data);
 
         var addr = parsed.address ? parsed.address.toString() : '';
+
+        // keep address in original formal
+        if (parsed.address && data.indexOf(addr)<0) {
+          addr = parsed.address.toCashAddress();
+        };
+
         var message = parsed.message;
 
         var amount = parsed.amount ? parsed.amount : '';

--- a/src/js/services/incomingData.js
+++ b/src/js/services/incomingData.js
@@ -110,6 +110,7 @@ angular.module('copayApp.services').factory('incomingData', function($log, $stat
         return true;
     // Cash URI
     } else if (bitcoreCash.URI.isValid(data)) {
+
         var coin = 'bch';
         var parsed = new bitcoreCash.URI(data);
 
@@ -203,7 +204,8 @@ angular.module('copayApp.services').factory('incomingData', function($log, $stat
       if ($state.includes('tabs.scan')) {
         root.showMenu({
           data: data,
-          type: 'bitcoinAddress'
+          type: 'bitcoinAddress',
+          coin: 'btc',
         });
       } else {
         goToAmountPage(data);

--- a/src/js/services/walletService.js
+++ b/src/js/services/walletService.js
@@ -1001,7 +1001,7 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
 
   root.useLegacyAddress = function(wallet) {
     var config = configService.getSync();
-    var walletSettings = config.wallet.settings;
+    var walletSettings = config.wallet;
 
     return walletSettings.useLegacyAddress;
   };

--- a/src/js/services/walletService.js
+++ b/src/js/services/walletService.js
@@ -1269,7 +1269,11 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
   };
 
   root.getProtocolHandler = function(wallet) {
-    if (wallet.coin== 'bch') return 'bitcoincash';
+    var config = configService.getSync();
+    if (wallet.coin== 'bch') {
+      if (config.wallet.settings.useLegacyAddress) return 'bitcoincash';
+      return;
+    }
     else return 'bitcoin';
   }
 

--- a/src/js/services/walletService.js
+++ b/src/js/services/walletService.js
@@ -1009,7 +1009,8 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
   root.getAddressView = function(wallet, address) {
     if (wallet.coin != 'bch' || root.useLegacyAddress(wallet)) return address;
 
-    return (new bitcoreCash.Address(address)).toCashAddress();;
+    var cashAddr= (new bitcoreCash.Address(address)).toCashAddress();;
+    return cashAddr.split(':')[1]; // rm prefix
   };
 
 
@@ -1285,10 +1286,10 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
   root.getProtocolHandler = function(wallet) {
 
     if (wallet.coin== 'bch') {
-      if (root.useLegacyAddress(wallet)) return 'bitcoincash';
-      return;
+      return 'bitcoincash';
+    } else {
+      return 'bitcoin';
     }
-    else return 'bitcoin';
   }
 
 

--- a/src/js/services/walletService.js
+++ b/src/js/services/walletService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('copayApp.services').factory('walletService', function($log, $timeout, lodash, trezor, ledger, intelTEE, storageService, configService, rateService, uxLanguage, $filter, gettextCatalog, bwcError, $ionicPopup, fingerprintService, ongoingProcess, gettext, $rootScope, txFormatService, $ionicModal, $state, bwcService, bitcore, popupService, feeService) {
+angular.module('copayApp.services').factory('walletService', function($log, $timeout, lodash, trezor, ledger, intelTEE, storageService, configService, rateService, uxLanguage, $filter, gettextCatalog, bwcError, $ionicPopup, fingerprintService, ongoingProcess, gettext, $rootScope, txFormatService, $ionicModal, $state, bwcService, bitcore, bitcoreCash, popupService, feeService) {
 
   // Ratio low amount warning (fee/amount) in incoming TX
   var LOW_AMOUNT_RATIO = 0.15;
@@ -999,6 +999,16 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
     });
   };
 
+  root.getAddressView = function(wallet, address) {
+    var config = configService.getSync();
+    var walletSettings = config.wallet.settings;
+
+    if (wallet.coin != 'bch' || walletSettings.useLegacyAddress) return address;
+
+    return (new bitcoreCash.Address(address)).toCashAddress();;
+  };
+
+
   root.getAddress = function(wallet, forceNew, cb) {
     storageService.getLastAddress(wallet.id, function(err, addr) {
       if (err) return cb(err);
@@ -1270,6 +1280,7 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
 
   root.getProtocolHandler = function(wallet) {
     var config = configService.getSync();
+
     if (wallet.coin== 'bch') {
       if (config.wallet.settings.useLegacyAddress) return 'bitcoincash';
       return;

--- a/src/js/services/walletService.js
+++ b/src/js/services/walletService.js
@@ -999,11 +999,15 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
     });
   };
 
-  root.getAddressView = function(wallet, address) {
+  root.useLegacyAddress = function(wallet) {
     var config = configService.getSync();
     var walletSettings = config.wallet.settings;
 
-    if (wallet.coin != 'bch' || walletSettings.useLegacyAddress) return address;
+    return walletSettings.useLegacyAddress;
+  };
+
+  root.getAddressView = function(wallet, address) {
+    if (wallet.coin != 'bch' || root.useLegacyAddress(wallet)) return address;
 
     return (new bitcoreCash.Address(address)).toCashAddress();;
   };
@@ -1279,10 +1283,9 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
   };
 
   root.getProtocolHandler = function(wallet) {
-    var config = configService.getSync();
 
     if (wallet.coin== 'bch') {
-      if (config.wallet.settings.useLegacyAddress) return 'bitcoincash';
+      if (root.useLegacyAddress(wallet)) return 'bitcoincash';
       return;
     }
     else return 'bitcoin';

--- a/www/views/advancedSettings.html
+++ b/www/views/advancedSettings.html
@@ -17,6 +17,17 @@
 
       <div class="item item-divider"></div>
 
+      <ion-toggle class="has-comment" ng-model="useLegacyAddress.value" toggle-class="toggle-balanced" ng-change="useLegacyAddressChange()">
+        <span class="toggle-label" translate>Use Bitcoin Cash Copay Style Addresses</span>
+      </ion-toggle>
+      <div class="comment" translate>
+        If enabled, Bitcoin Cash addresses will be shown using Copay style address, and not the new cashaddr format.
+      </div>
+
+      <div class="item item-divider"></div>
+
+
+
       <ion-toggle class="has-comment" ng-model="recentTransactionsEnabled.value" toggle-class="toggle-balanced" ng-change="recentTransactionsChange()">
         <span class="toggle-label" translate>Recent Transaction Card</span>
       </ion-toggle>

--- a/www/views/confirm.html
+++ b/www/views/confirm.html
@@ -47,8 +47,8 @@
           <span class="payment-proposal-to" ng-if="!recipientType">
             <img src="img/icon-bitcoin-small.svg">
 
-            <div copy-to-clipboard="tx.toAddress" ng-if="!tx.paypro" class="ellipsis">
-              <contact ng-if="tx.toAddress && !tx.toName" address="{{tx.toAddress}}"></contact>
+            <div copy-to-clipboard="tx.origToAddress" ng-if="!tx.paypro" class="ellipsis">
+              <contact ng-if="tx.origToAddress && !tx.toName" address="{{tx.origToAddress}}"></contact>
               <span class="m15l size-14" ng-if="tx.toName">{{tx.toName}}</span>
             </div>
 
@@ -65,15 +65,15 @@
             <i class="icon big-icon-svg">
               <img src="img/icon-wallet.svg" ng-class="{'wallet-background-color-default': !toColor}" ng-style="{'background-color': toColor}" class="bg"/>
             </i>
-            <div copy-to-clipboard="tx.toAddress" class="ellipsis">
-              <contact ng-if="tx.toAddress && !tx.toName" address="{{tx.toAddress}}"></contact>
+            <div copy-to-clipboard="tx.origToAddress" class="ellipsis">
+              <contact ng-if="tx.origToAddress && !tx.toName" address="{{tx.origToAddress}}"></contact>
               <span ng-if="tx.toName" class="wallet-name">{{tx.toName}}</span>
             </div>
           </div>
           <div ng-if="recipientType == 'contact' && !isChromeApp" class="gravatar-contact toggle" ng-click="toggleAddress()">
             <gravatar class="send-gravatar" name="{{tx.toName}}" height="30" width="30" email="{{toEmail}}"></gravatar>
             <span ng-if="tx.toName && !showAddress">{{tx.toName}}</span>
-            <span ng-if="tx.toName && showAddress">{{tx.toAddress}}</span>
+            <span ng-if="tx.toName && showAddress">{{tx.origToAddress}}</span>
           </div>
         </div>
 

--- a/www/views/customAmount.html
+++ b/www/views/customAmount.html
@@ -21,7 +21,7 @@
   <ion-content scroll="false">
     <div class="address" ng-if="address && amountBtc">
       <div class="qr-code" copy-to-clipboard="copyToClipboard()">
-        <qrcode size="220" data="{{ protocolHandler }}:{{address + '?amount=' + amountBtc}}" color="#334"></qrcode>
+        <qrcode size="220" data="{{protoAddr + '?amount=' + amountBtc}}" color="#334"></qrcode>
       </div>
       <div class="info">
         <div class="item single-line" copy-to-clipboard="address">

--- a/www/views/includes/incomingDataMenu.html
+++ b/www/views/includes/incomingDataMenu.html
@@ -41,7 +41,7 @@
       <div class="incoming-data-menu__item__text" translate>Add as a contact</div>
       <i class="icon bp-arrow-right"></i>
     </a>
-    <a class="incoming-data-menu__item item item-icon-right" ng-click="sendPaymentToAddress(data)">
+    <a class="incoming-data-menu__item item item-icon-right" ng-click="sendPaymentToAddress(data, coin)">
       <img src="img/icon-send-alt.svg">
       <div class="incoming-data-menu__item__text" translate>Send payment to this address</div>
       <i class="icon bp-arrow-right"></i>

--- a/www/views/tab-receive.html
+++ b/www/views/tab-receive.html
@@ -34,7 +34,7 @@
               <span translate>Show address</span>
             </button>
           </span>
-          <qrcode ng-if="addr" size="220" data="{{ protocolHandler }}:{{addr}}" color="#334"></qrcode>
+          <qrcode ng-if="addr" size="220" data="{{ protoAddr}}" color="#334"></qrcode>
           <div class="address-label">
             <span class="ellipsis">{{addr}}</span>
             <ion-spinner ng-show="!addr" class="spinner-dark" icon="crescent"></ion-spinner>

--- a/www/views/tab-receive.html
+++ b/www/views/tab-receive.html
@@ -34,7 +34,7 @@
               <span translate>Show address</span>
             </button>
           </span>
-          <qrcode ng-if="addr" size="220" data="{{ protoAddr}}" color="#334"></qrcode>
+          <qrcode ng-if="addr"  size="220" data="{{ protoAddr}}" color="#334"></qrcode>
           <div class="address-label">
             <span class="ellipsis">{{addr}}</span>
             <ion-spinner ng-show="!addr" class="spinner-dark" icon="crescent"></ion-spinner>


### PR DESCRIPTION
already working in receive and  send.

ToDo:
- [x] generate receive QRs
- [x] parse QRs 
- [x]  generate receive specific amount
- [x] test edge cases (up/lower case)
- [x] keep cashaddr format after scanned (now it is "transformed" to Copay addr in /amount)
- [x] hide prefix when showing address to the user
- [x] parse recieved specific amount (failing)
- [x] add config option and replace in walletService
- [x] check paypro