### PR TITLE
Shift: save data almost immediately after send transaction

### DIFF
--- a/src/js/controllers/shapeshiftConfirm.js
+++ b/src/js/controllers/shapeshiftConfirm.js
@@ -302,7 +302,7 @@ angular.module('copayApp.controllers').controller('shapeshiftConfirmController',
           return;
         }
         $scope.txSent = txSent;
-        $timeout(function() { saveShapeshiftData(); }, 2000);
+        $timeout(function() { saveShapeshiftData(); }, 500);
         $timeout(function() { $scope.$digest(); }, 100);
       });
     });


### PR DESCRIPTION
Could happen that the new transaction doesn't appear in the main view of ShapeShift.