### PR TITLE
Fix path format of new addresses in UI

### DIFF
--- a/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-addresses/wallet-addresses.ts
+++ b/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-addresses/wallet-addresses.ts
@@ -131,6 +131,9 @@ export class WalletAddressesPage {
           return;
         }
         this.noBalance = [_addr[0]].concat(this.noBalance);
+
+        this.processList(this.noBalance);
+
         this.latestUnused = _.slice(this.noBalance, 0, this.UNUSED_ADDRESS_LIMIT);
         this.viewAll = this.noBalance.length > this.UNUSED_ADDRESS_LIMIT;
       }).catch((err) => {


### PR DESCRIPTION
When you generate a new address by pressing "+" in "Wallet Addresses", the path of the address is prefixed by `m/` instead of `xpub/`, which is used for existing addresses in UI.

![screen shot 2018-03-05 at 13 55 45](https://user-images.githubusercontent.com/322125/36958548-fc88b068-207f-11e8-99e2-a334d6785cbc.png)

This pull request will fix the issue.