### PR TITLE
Fix: removes async function when creating new address

### DIFF
--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -379,10 +379,9 @@ export class WalletProvider {
         if (err) {
           let prefix = this.translate.instant('Could not create address');
           if (err instanceof this.errors.CONNECTION_ERROR || (err.message && err.message.match(/5../))) {
-            this.logger.warn('Could not create address', err);
-            return setTimeout(() => {
-              this.createAddress(wallet);
-            }, 5000);
+            this.bwcErrorProvider.cb(err, prefix).then((msg) => {
+              return reject(msg);
+            });
           } else if (
             err instanceof this.errors.MAIN_ADDRESS_GAP_REACHED || (err.message && err.message == 'MAIN_ADDRESS_GAP_REACHED')
           ) {


### PR DESCRIPTION
This causes an unexpected call to a promise and could be store incorrect information. Only return an error in console.log.