### PR TITLE
Fix css iOS scroll styling regression

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -54,6 +54,7 @@ ion-alert.alert-top {
 .scroll-content {
   .wrapper {
     background-color: $background-color;
+    min-height: 60%;
   }
 }
 
@@ -349,6 +350,6 @@ ion-alert .alert-message {
 .mdToastAfterHeader {
   top: $toolbar-md-height;
 }
-.iosToastAfterHeader{
+.iosToastAfterHeader {
   top: $toolbar-ios-height;
 }

--- a/src/pages/home/home.scss
+++ b/src/pages/home/home.scss
@@ -68,4 +68,17 @@ page-home {
       margin-top: -25px;
     }
   }
+
+  .scroll-content {
+    // This line prevents an ugly gap from appearing between the
+    // navbar and page content when the user overscrolls on iOS
+    background-image: linear-gradient(
+      to bottom,
+      $toolbar-background,
+      $toolbar-background 50%,
+      $background-color 50%,
+      $background-color 50%,
+      $background-color 50%
+    );
+  }
 }

--- a/src/pages/wallet-details/wallet-details.html
+++ b/src/pages/wallet-details/wallet-details.html
@@ -122,8 +122,6 @@
       <span translate>{{updatingTxHistoryProgress}} transactions downloaded</span>
     </div>
 
-    <div *ngIf="!(history && history[0])" class="loading-spacer"></div>
-
     <ion-list *ngIf="history && history[0]" class="tx-history">
       <div *ngFor="let tx of history; trackBy: trackByFn; let i = index">
 
@@ -144,7 +142,8 @@
             </div>
             <div *ngIf="tx.confirmations > 0">
               <span *ngIf="tx.customData && tx.customData.service">
-                <img class="icon-services" src="assets/img/shapeshift/icon-shapeshift.svg" *ngIf="tx.customData.service == 'shapeshift'" width="40">
+                <img class="icon-services" src="assets/img/shapeshift/icon-shapeshift.svg" *ngIf="tx.customData.service == 'shapeshift'"
+                  width="40">
                 <img class="icon-services" src="assets/img/amazon/icon-amazon.svg" *ngIf="tx.customData.service == 'amazon'" width="40">
                 <img class="icon-services" src="assets/img/mercado-libre/icon-ml.svg" *ngIf="tx.customData.service == 'mercadolibre'" width="40">
                 <img class="icon-services" src="assets/img/bitpay-card/icon-bitpay.svg" *ngIf="tx.customData.service == 'debitcard'" width="40">

--- a/src/pages/wallet-details/wallet-details.scss
+++ b/src/pages/wallet-details/wallet-details.scss
@@ -64,10 +64,6 @@ page-wallet-details {
       font-weight: 500;
     }
   }
-  .loading-spacer {
-    height: 500px;
-    width: 100%;
-  }
   .tx-history {
     img {
       width: 35px;


### PR DESCRIPTION
Not sure why this line was removed here https://github.com/bitpay/copay/pull/8453/files#diff-3c303face59d40ba5031ed6c51449334L52, but this line is necessary to ensure no ugly gaps appear on iOS when the user over-scrolls.

Spoke with @Gamboster, and it turns out those lines were removed to prevent issue #8420. I've updated my PR to fix both issues.