### PR TITLE
Fix: set the home page after an error occurs when scanning a QR

### DIFF
--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -242,12 +242,7 @@ export class ConfirmPage {
   private exitWithError(err: any) {
     this.logger.info('Error setting wallet selector:' + err);
     this.popupProvider.ionicAlert("", this.bwcErrorProvider.msg(err)).then(() => {
-      this.navCtrl.popToRoot({ animate: false }).then(() => {
-        // Fixes mobile navigation
-        setTimeout(() => {
-          this.navCtrl.parent.select(0);
-        });
-      });
+      this.app.getRootNavs()[0].setRoot(TabsPage);
     });
   };
 


### PR DESCRIPTION
For example, when you do not have enough funds after scanning a code, the application navigates to scan page and then to home page. With this fix directly navigate to home page avoiding turning on the camera again.