### PR TITLE
Simplify page tests, and fix TimeProvider bug

### DIFF
--- a/src/pages/home/home.spec.ts
+++ b/src/pages/home/home.spec.ts
@@ -5,15 +5,13 @@ import {
   TestBed
 } from '@angular/core/testing';
 
-import { Platform } from 'ionic-angular';
 import { Subject } from 'rxjs';
 
 import { TestUtils } from '../../test';
 
-import { HomePage } from './home';
-
 import { AddressBookProvider } from '../../providers/address-book/address-book';
 import { ConfigProvider } from './../../providers/config/config';
+import { HomePage } from './home';
 
 describe('HomePage', () => {
   let fixture: ComponentFixture<HomePage>;
@@ -27,7 +25,7 @@ describe('HomePage', () => {
         instance = testEnv.instance;
         testBed = testEnv.testBed;
         instance.showCard = {
-          setShowRateCard: () => { }
+          setShowRateCard: () => {}
         };
         fixture.detectChanges();
       })
@@ -81,5 +79,4 @@ describe('HomePage', () => {
       });
     });
   });
-
 });

--- a/src/pages/send/confirm/confirm.spec.ts
+++ b/src/pages/send/confirm/confirm.spec.ts
@@ -12,39 +12,6 @@ import { TestUtils } from '../../../test';
 
 import { ConfirmPage } from './confirm';
 
-import { AddressBookProvider } from '../../../providers/address-book/address-book';
-import { AppIdentityProvider } from '../../../providers/app-identity/app-identity';
-import { AppProvider } from '../../../providers/app/app';
-import { BitPayCardProvider } from '../../../providers/bitpay-card/bitpay-card';
-import { BitPayProvider } from '../../../providers/bitpay/bitpay';
-import { ExternalLinkProvider } from '../../../providers/external-link/external-link';
-import { FeeProvider } from '../../../providers/fee/fee';
-import { FeedbackProvider } from '../../../providers/feedback/feedback';
-import { FilterProvider } from '../../../providers/filter/filter';
-import { HomeIntegrationsProvider } from '../../../providers/home-integrations/home-integrations';
-import { IncomingDataProvider } from '../../../providers/incoming-data/incoming-data';
-import { LanguageProvider } from '../../../providers/language/language';
-import { NodeWebkitProvider } from '../../../providers/node-webkit/node-webkit';
-import { OnGoingProcessProvider } from '../../../providers/on-going-process/on-going-process';
-import { PayproProvider } from '../../../providers/paypro/paypro';
-import { PlatformProvider } from '../../../providers/platform/platform';
-import { PopupProvider } from '../../../providers/popup/popup';
-import { PushNotificationsProvider } from '../../../providers/push-notifications/push-notifications';
-import { RateProvider } from '../../../providers/rate/rate';
-import { ReleaseProvider } from '../../../providers/release/release';
-import { ReplaceParametersProvider } from '../../../providers/replace-parameters/replace-parameters';
-import { ScanProvider } from '../../../providers/scan/scan';
-import { TouchIdProvider } from '../../../providers/touchid/touchid';
-import { TxConfirmNotificationProvider } from '../../../providers/tx-confirm-notification/tx-confirm-notification';
-import { TxFormatProvider } from '../../../providers/tx-format/tx-format';
-import { WalletProvider } from '../../../providers/wallet/wallet';
-import { BwcErrorProvider } from './../../../providers/bwc-error/bwc-error';
-import { BwcProvider } from './../../../providers/bwc/bwc';
-import { ConfigProvider } from './../../../providers/config/config';
-import { Logger } from './../../../providers/logger/logger';
-import { PersistenceProvider } from './../../../providers/persistence/persistence';
-import { ProfileProvider } from './../../../providers/profile/profile';
-
 describe('ConfirmPage', () => {
   let fixture: ComponentFixture<ConfirmPage>;
   let instance: any;
@@ -52,40 +19,7 @@ describe('ConfirmPage', () => {
 
   beforeEach(
     async(() =>
-      TestUtils.configurePageTestingModule([ConfirmPage], {
-        providers: [
-          AddressBookProvider,
-          AppIdentityProvider,
-          BitPayCardProvider,
-          BitPayProvider,
-          BwcProvider,
-          BwcErrorProvider,
-          ConfigProvider,
-          ExternalLinkProvider,
-          FeedbackProvider,
-          FeeProvider,
-          FilterProvider,
-          HomeIntegrationsProvider,
-          IncomingDataProvider,
-          LanguageProvider,
-          Logger,
-          NodeWebkitProvider,
-          OnGoingProcessProvider,
-          PayproProvider,
-          PersistenceProvider,
-          PopupProvider,
-          ProfileProvider,
-          PushNotificationsProvider,
-          RateProvider,
-          ReleaseProvider,
-          ReplaceParametersProvider,
-          ScanProvider,
-          TouchIdProvider,
-          TxConfirmNotificationProvider,
-          TxFormatProvider,
-          WalletProvider
-        ]
-      }).then(testEnv => {
+      TestUtils.configurePageTestingModule([ConfirmPage]).then(testEnv => {
         fixture = testEnv.fixture;
         instance = testEnv.instance;
         testBed = testEnv.testBed;
@@ -157,8 +91,8 @@ describe('ConfirmPage', () => {
     describe('chooseFeeLevel', () => {
       it('should display a fee modal', () => {
         const modal = {
-          present: () => { },
-          onDidDismiss: () => { }
+          present: () => {},
+          onDidDismiss: () => {}
         };
         const presentSpy = spyOn(modal, 'present');
         instance.modalCtrl.create = () => modal;
@@ -259,9 +193,6 @@ describe('ConfirmPage', () => {
         await instance.onlyPublish();
         expect(setErrorSpy).toHaveBeenCalled();
       });
-    });
-    describe('publishAndSign', () => {
-      it('should work', () => { });
     });
   });
 });

--- a/src/pages/wallet-details/search-tx-modal/search-tx-modal.ts
+++ b/src/pages/wallet-details/search-tx-modal/search-tx-modal.ts
@@ -11,10 +11,9 @@ import { TxDetailsPage } from '../../tx-details/tx-details';
 
 @Component({
   selector: 'page-search-tx-modal',
-  templateUrl: 'search-tx-modal.html',
+  templateUrl: 'search-tx-modal.html'
 })
 export class SearchTxModalPage {
-
   private HISTORY_SHOW_LIMIT: number;
   private currentTxHistoryPage: number;
 
@@ -52,7 +51,10 @@ export class SearchTxModalPage {
   }
 
   private throttleSearch = _.throttle((search: string) => {
-    this.txHistorySearchResults = this.filter(search).slice(0, this.HISTORY_SHOW_LIMIT);
+    this.txHistorySearchResults = this.filter(search).slice(
+      0,
+      this.HISTORY_SHOW_LIMIT
+    );
   }, 1000);
 
   private filter(search: string): any[] {
@@ -64,24 +66,40 @@ export class SearchTxModalPage {
     }
 
     this.filteredTxHistory = _.filter(this.completeTxHistory, (tx: any) => {
-      if (!tx.searcheableString) tx.searcheableString = this.computeSearchableString(tx);
+      if (!tx.searcheableString)
+        tx.searcheableString = this.computeSearchableString(tx);
       return _.includes(tx.searcheableString, search.toLowerCase());
     });
 
-    this.txHistoryShowMore = this.filteredTxHistory.length > this.HISTORY_SHOW_LIMIT ? true : false;
+    this.txHistoryShowMore =
+      this.filteredTxHistory.length > this.HISTORY_SHOW_LIMIT ? true : false;
 
     return this.filteredTxHistory;
   }
 
   private computeSearchableString(tx: any): any {
     let addrbook = '';
-    if (tx.addressTo && this.addressbook && this.addressbook[tx.addressTo]) addrbook = this.addressbook[tx.addressTo].name || this.addressbook[tx.addressTo] || '';
+    if (tx.addressTo && this.addressbook && this.addressbook[tx.addressTo])
+      addrbook =
+        this.addressbook[tx.addressTo].name ||
+        this.addressbook[tx.addressTo] ||
+        '';
     let searchableDate = this.computeSearchableDate(new Date(tx.time * 1000));
     let message = tx.message ? tx.message : '';
     let comment = tx.note ? tx.note.body : '';
     let addressTo = tx.addressTo ? tx.addressTo : '';
     let txid = tx.txid ? tx.txid : '';
-    return ((tx.amountStr + message + addressTo + addrbook + searchableDate + comment + txid).toString()).toLowerCase();
+    return (
+      tx.amountStr +
+      message +
+      addressTo +
+      addrbook +
+      searchableDate +
+      comment +
+      txid
+    )
+      .toString()
+      .toLowerCase();
   }
 
   private computeSearchableDate(date: Date): string {
@@ -100,15 +118,21 @@ export class SearchTxModalPage {
   }
 
   public showHistory(): void {
-    this.txHistorySearchResults = this.filteredTxHistory ? this.filteredTxHistory.slice(0, (this.currentTxHistoryPage + 1) * this.HISTORY_SHOW_LIMIT) : [];
-    this.txHistoryShowMore = this.filteredTxHistory.length > this.txHistorySearchResults.length;
+    this.txHistorySearchResults = this.filteredTxHistory
+      ? this.filteredTxHistory.slice(
+          0,
+          (this.currentTxHistoryPage + 1) * this.HISTORY_SHOW_LIMIT
+        )
+      : [];
+    this.txHistoryShowMore =
+      this.filteredTxHistory.length > this.txHistorySearchResults.length;
   }
 
   public trackByFn(index: number, tx: any): number {
     return index;
   }
 
-  public createdWithinPastDay(time: any): void {
+  public createdWithinPastDay(time: any): boolean {
     return this.timeProvider.withinPastDay(time);
   }
 
@@ -118,5 +142,4 @@ export class SearchTxModalPage {
       txid: tx.txid
     });
   }
-
 }

--- a/src/pages/wallet-details/wallet-details.html
+++ b/src/pages/wallet-details/wallet-details.html
@@ -146,7 +146,8 @@
                 </div>
                 <div *ngIf="tx.confirmations > 0">
                   <span *ngIf="tx.customData && tx.customData.service">
-                    <img class="icon-services" src="assets/img/shapeshift/icon-shapeshift.svg" *ngIf="tx.customData.service == 'shapeshift'" width="40">
+                    <img class="icon-services" src="assets/img/shapeshift/icon-shapeshift.svg" *ngIf="tx.customData.service == 'shapeshift'"
+                      width="40">
                     <img class="icon-services" src="assets/img/amazon/icon-amazon.svg" *ngIf="tx.customData.service == 'amazon'" width="40">
                     <img class="icon-services" src="assets/img/mercado-libre/icon-ml.svg" *ngIf="tx.customData.service == 'mercadolibre'" width="40">
                     <img class="icon-services" src="assets/img/bitpay-card/icon-bitpay.svg" *ngIf="tx.customData.service == 'debitcard'" width="40">

--- a/src/pages/wallet-details/wallet-details.spec.ts
+++ b/src/pages/wallet-details/wallet-details.spec.ts
@@ -5,45 +5,10 @@ import {
   TestBed
 } from '@angular/core/testing';
 
-import { Platform } from 'ionic-angular';
-import { Subject } from 'rxjs';
-
 import { TestUtils } from '../../test';
 
-import { WalletDetailsPage } from './wallet-details';
-
-import { AddressBookProvider } from '../../providers/address-book/address-book';
-import { AppIdentityProvider } from '../../providers/app-identity/app-identity';
-import { AppProvider } from '../../providers/app/app';
-import { BitPayCardProvider } from '../../providers/bitpay-card/bitpay-card';
-import { BitPayProvider } from '../../providers/bitpay/bitpay';
-import { ExternalLinkProvider } from '../../providers/external-link/external-link';
-import { FeeProvider } from '../../providers/fee/fee';
-import { FeedbackProvider } from '../../providers/feedback/feedback';
-import { FilterProvider } from '../../providers/filter/filter';
-import { HomeIntegrationsProvider } from '../../providers/home-integrations/home-integrations';
-import { IncomingDataProvider } from '../../providers/incoming-data/incoming-data';
-import { LanguageProvider } from '../../providers/language/language';
-import { NodeWebkitProvider } from '../../providers/node-webkit/node-webkit';
-import { OnGoingProcessProvider } from '../../providers/on-going-process/on-going-process';
-import { PayproProvider } from '../../providers/paypro/paypro';
-import { PlatformProvider } from '../../providers/platform/platform';
-import { PopupProvider } from '../../providers/popup/popup';
-import { PushNotificationsProvider } from '../../providers/push-notifications/push-notifications';
-import { RateProvider } from '../../providers/rate/rate';
-import { ReleaseProvider } from '../../providers/release/release';
-import { ReplaceParametersProvider } from '../../providers/replace-parameters/replace-parameters';
-import { ScanProvider } from '../../providers/scan/scan';
-import { TimeProvider } from '../../providers/time/time';
-import { TouchIdProvider } from '../../providers/touchid/touchid';
-import { TxFormatProvider } from '../../providers/tx-format/tx-format';
-import { WalletProvider } from '../../providers/wallet/wallet';
-import { BwcErrorProvider } from './../../providers/bwc-error/bwc-error';
-import { BwcProvider } from './../../providers/bwc/bwc';
-import { ConfigProvider } from './../../providers/config/config';
-import { Logger } from './../../providers/logger/logger';
-import { PersistenceProvider } from './../../providers/persistence/persistence';
 import { ProfileProvider } from './../../providers/profile/profile';
+import { WalletDetailsPage } from './wallet-details';
 
 describe('WalletDetailsPage', () => {
   let fixture: ComponentFixture<WalletDetailsPage>;
@@ -62,45 +27,14 @@ describe('WalletDetailsPage', () => {
         isPrivKeyEncrypted: () => true
       };
       spyOn(ProfileProvider.prototype, 'getWallet').and.returnValue(mockWallet);
-      return TestUtils.configurePageTestingModule([WalletDetailsPage], {
-        providers: [
-          AddressBookProvider,
-          AppIdentityProvider,
-          BitPayCardProvider,
-          BitPayProvider,
-          BwcProvider,
-          BwcErrorProvider,
-          ConfigProvider,
-          ExternalLinkProvider,
-          FeedbackProvider,
-          FeeProvider,
-          FilterProvider,
-          HomeIntegrationsProvider,
-          IncomingDataProvider,
-          LanguageProvider,
-          Logger,
-          NodeWebkitProvider,
-          OnGoingProcessProvider,
-          PayproProvider,
-          PersistenceProvider,
-          PopupProvider,
-          ProfileProvider,
-          PushNotificationsProvider,
-          RateProvider,
-          ReleaseProvider,
-          ReplaceParametersProvider,
-          ScanProvider,
-          TimeProvider,
-          TouchIdProvider,
-          TxFormatProvider,
-          WalletProvider
-        ]
-      }).then(testEnv => {
-        fixture = testEnv.fixture;
-        instance = testEnv.instance;
-        testBed = testEnv.testBed;
-        fixture.detectChanges();
-      });
+      return TestUtils.configurePageTestingModule([WalletDetailsPage]).then(
+        testEnv => {
+          fixture = testEnv.fixture;
+          instance = testEnv.instance;
+          testBed = testEnv.testBed;
+          fixture.detectChanges();
+        }
+      );
     })
   );
   afterEach(() => {
@@ -160,7 +94,7 @@ describe('WalletDetailsPage', () => {
     describe('showHistory', () => {
       it('should add the next page of transactions to the list', () => {
         instance.currentPage = 0;
-        instance.wallet.completeHistory = new Array(11).map(() => { });
+        instance.wallet.completeHistory = new Array(11).map(() => {});
         const spy = spyOn(instance, 'groupHistory');
         instance.showHistory();
         expect(instance.history.length).toBe(10);

--- a/src/pages/wallet-details/wallet-details.spec.ts
+++ b/src/pages/wallet-details/wallet-details.spec.ts
@@ -8,6 +8,7 @@ import {
 import { TestUtils } from '../../test';
 
 import { ProfileProvider } from './../../providers/profile/profile';
+import { TimeProvider } from './../../providers/time/time';
 import { WalletDetailsPage } from './wallet-details';
 
 describe('WalletDetailsPage', () => {
@@ -100,6 +101,18 @@ describe('WalletDetailsPage', () => {
         expect(instance.history.length).toBe(10);
         expect(instance.currentPage).toBe(1);
         expect(spy).toHaveBeenCalled();
+      });
+    });
+    describe('isDateInCurrentMonth', () => {
+      it('should use timeProvider.isDateInCurrentMonth', () => {
+        const spy = spyOn(
+          instance.timeProvider,
+          'isDateInCurrentMonth'
+        ).and.callThrough();
+        const date = new Date();
+        const inMonth = instance.isDateInCurrentMonth(date);
+        expect(inMonth).toBe(true);
+        expect(spy).toHaveBeenCalledWith(date);
       });
     });
   });

--- a/src/pages/wallet-details/wallet-details.ts
+++ b/src/pages/wallet-details/wallet-details.ts
@@ -1,6 +1,11 @@
 import { Component } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { Events, ModalController, NavController, NavParams } from 'ionic-angular';
+import {
+  Events,
+  ModalController,
+  NavController,
+  NavParams
+} from 'ionic-angular';
 import * as _ from 'lodash';
 
 // providers
@@ -152,7 +157,7 @@ export class WalletDetailsPage {
     this.updateTxHistoryError = false;
     this.updatingTxHistoryProgress = 0;
 
-    let progressFn = function (txs, newTxs) {
+    let progressFn = function(txs, newTxs) {
       if (newTxs > 5) this.thistory = null;
       this.updatingTxHistoryProgress = newTxs;
     }.bind(this);
@@ -317,7 +322,15 @@ export class WalletDetailsPage {
   }
 
   public openSearchModal(): void {
-    let modal = this.modalCtrl.create(SearchTxModalPage, { addressbook: this.addressbook, completeHistory: this.wallet.completeHistory, wallet: this.wallet }, { showBackdrop: false, enableBackdropDismiss: true });
+    let modal = this.modalCtrl.create(
+      SearchTxModalPage,
+      {
+        addressbook: this.addressbook,
+        completeHistory: this.wallet.completeHistory,
+        wallet: this.wallet
+      },
+      { showBackdrop: false, enableBackdropDismiss: true }
+    );
     modal.present();
   }
 }

--- a/src/providers/time/time.spec.ts
+++ b/src/providers/time/time.spec.ts
@@ -1,0 +1,18 @@
+import { TimeProvider } from './time';
+
+describe('TimeProvider', () => {
+  const timeProvider = new TimeProvider();
+  describe('getMonthYear', () => {
+    it('should concatenate the month and year into a string', () => {
+      const monthYear = timeProvider.getMonthYear(new Date('Jan 1, 2020'));
+      expect(monthYear).toBe('0-2020');
+    });
+    it('should distinguish between dates whose month and year sum to the same value', () => {
+      const date1 = new Date('Jan 1, 2020'); // month 0, year 2020, sum 2020
+      const date2 = new Date('Feb 1, 2019'); // month 1, year 2019, sum 2020
+      const monthYear1 = timeProvider.getMonthYear(date1);
+      const monthYear2 = timeProvider.getMonthYear(date2);
+      expect(monthYear1).not.toEqual(monthYear2);
+    });
+  });
+});

--- a/src/providers/time/time.ts
+++ b/src/providers/time/time.ts
@@ -2,30 +2,27 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class TimeProvider {
+  constructor() {}
 
-  constructor(
-  ) { }
-
-  public withinSameMonth(time1: any, time2: any): any {
+  public withinSameMonth(time1: number, time2: number): boolean {
     if (!time1 || !time2) return false;
     let date1 = new Date(time1);
     let date2 = new Date(time2);
     return this.getMonthYear(date1) === this.getMonthYear(date2);
   }
 
-  public withinPastDay(time: any): any {
+  public withinPastDay(time: any): boolean {
     let now = new Date();
     let date = new Date(time);
-    return (now.getTime() - date.getTime()) < (1000 * 60 * 60 * 24);
+    return now.getTime() - date.getTime() < 1000 * 60 * 60 * 24;
   }
 
-  public isDateInCurrentMonth(date: any): any {
+  public isDateInCurrentMonth(date: Date): boolean {
     let now = new Date();
     return this.getMonthYear(now) === this.getMonthYear(date);
-  };
-
-  public getMonthYear(date: any): any {
-    return date.getMonth() + date.getFullYear();
   }
 
+  public getMonthYear(date: Date): string {
+    return `${date.getMonth()}-${date.getFullYear()}`;
+  }
 }


### PR DESCRIPTION
Now that https://github.com/bitpay/copay/pull/8485 has been merged, we can now greatly simplify page tests by using the providers module rather than having to import each provider dependency manually.

This PR also fixes a bug with the `getMonthYear` method in `TimeProvider`.