### PR TITLE
FEAT: show transaction id in transactions details ( copy to clipboard added )

### DIFF
--- a/src/pages/tx-details/tx-details.html
+++ b/src/pages/tx-details/tx-details.html
@@ -126,6 +126,15 @@
       </div>
     </button>
 
+    <ion-item class="container-tx-id">
+      <span translate>Transaction ID</span>
+      <div class="tx-id">
+        <div class="ellipsis id" copy-to-clipboard="{{ btx.txid }}">
+          <span>{{ btx.txid }}</span>
+        </div>
+      </div>
+    </ion-item>
+
     <ion-item *ngIf="txsUnsubscribedForNotifications">
       <ion-label>{{'Notify me if confirmed' | translate}}</ion-label>
       <ion-toggle checked="false" *ngIf="!btx.confirmations || btx.confirmations == 0" [(ngModel)]="txNotification.value" (ionChange)="txConfirmNotificationChange()"></ion-toggle>

--- a/src/pages/tx-details/tx-details.scss
+++ b/src/pages/tx-details/tx-details.scss
@@ -55,8 +55,8 @@ page-tx-details {
     margin-top: 1rem;
   }
 
-  .container-to, .container-from {
-    .wallet, .payment-to {
+  .container-to, .container-from, .container-tx-id {
+    .wallet, .payment-to, .tx-id {
       @include row-flex;
       .icon-wallet {
         width: 25px;
@@ -74,6 +74,10 @@ page-tx-details {
         padding: 3px 8px;
         border: 1px solid color($colors, grey);
         border-radius: $icon-border-radius;
+      }
+      .id {
+        font-size: 12.5px;
+        color: color($colors, light-grey);
       }
     }
   }


### PR DESCRIPTION
I think is really useful for users that need support to have this information (that is usually asked) no so hidden. 

![copay_-_copay_bitcoin_wallet](https://user-images.githubusercontent.com/10999037/39835751-8e21a692-53a7-11e8-8a70-2f44f0a3d861.png)
