### PR TITLE
Refactor: Use Promises instead of setTimeouts

### DIFF
--- a/src/pages/integrations/amazon/buy-amazon/buy-amazon.ts
+++ b/src/pages/integrations/amazon/buy-amazon/buy-amazon.ts
@@ -496,15 +496,10 @@ export class BuyAmazonPage {
     let finishText = '';
     let modal = this.modalCtrl.create(FinishModalPage, { finishText, finishComment, cssClass }, { showBackdrop: true, enableBackdropDismiss: false });
     modal.present();
-    modal.onDidDismiss(() => {
-      this.navCtrl.popToRoot({ animate: false }).then(() => {
-        this.navCtrl.parent.select(0);
-
-        // Fixes mobile navigation
-        setTimeout(() => {
-          this.navCtrl.push(AmazonPage, { invoiceId: this.invoiceId }, { animate: false });
-        }, 200);
-      });
+    modal.onDidDismiss(async () => {
+      await this.navCtrl.popToRoot({ animate: false });
+      await this.navCtrl.parent.select(0);
+      await this.navCtrl.push(AmazonPage, { invoiceId: this.invoiceId }, { animate: false });
     });
   }
 

--- a/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
+++ b/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
@@ -516,15 +516,10 @@ export class BitPayCardTopUpPage {
     let finishText = '';
     let modal = this.modalCtrl.create(FinishModalPage, { finishText, finishComment }, { showBackdrop: true, enableBackdropDismiss: false });
     modal.present();
-    modal.onDidDismiss(() => {
-      this.navCtrl.popToRoot({ animate: false }).then(() => {
-        this.navCtrl.parent.select(0);
-
-        // Fixes mobile navigation
-        setTimeout(() => {
-          this.navCtrl.push(BitPayCardPage, { id: this.cardId }, { animate: false });
-        }, 200);
-      });
+    modal.onDidDismiss(async () => {
+      await this.navCtrl.popToRoot({ animate: false });
+      await this.navCtrl.parent.select(0);
+      await this.navCtrl.push(BitPayCardPage, { id: this.cardId }, { animate: false });
     });
   }
 

--- a/src/pages/integrations/coinbase/buy-coinbase/buy-coinbase.ts
+++ b/src/pages/integrations/coinbase/buy-coinbase/buy-coinbase.ts
@@ -320,15 +320,10 @@ export class BuyCoinbasePage {
     let finishComment = 'Bitcoin purchase completed. Coinbase has queued the transfer to your selected wallet';
     let modal = this.modalCtrl.create(FinishModalPage, { finishText, finishComment }, { showBackdrop: true, enableBackdropDismiss: false });
     modal.present();
-    modal.onDidDismiss(() => {
-      this.navCtrl.popToRoot({ animate: false }).then(() => {
-        this.navCtrl.parent.select(0);
-
-        // Fixes mobile navigation
-        setTimeout(() => {
-          this.navCtrl.push(CoinbasePage, { coin: 'btc' }, { animate: false });
-        }, 200);
-      });
+    modal.onDidDismiss(async () => {
+      await this.navCtrl.popToRoot({ animate: false });
+      await this.navCtrl.parent.select(0);
+      await this.navCtrl.push(CoinbasePage, { coin: 'btc' }, { animate: false });
     });
   }
 

--- a/src/pages/integrations/coinbase/sell-coinbase/sell-coinbase.ts
+++ b/src/pages/integrations/coinbase/sell-coinbase/sell-coinbase.ts
@@ -386,17 +386,6 @@ export class SellCoinbasePage {
     let finishComment = 'The transaction is not yet confirmed, and will show as "Pending" in your Activity. The bitcoin sale will be completed automatically once it is confirmed by Coinbase';
     let modal = this.modalCtrl.create(FinishModalPage, { finishText, finishComment }, { showBackdrop: true, enableBackdropDismiss: false });
     modal.present();
-    modal.onDidDismiss(() => {
-      this.navCtrl.popToRoot({ animate: false }).then(() => {
-        this.navCtrl.parent.select(0);
-        
-        // Fixes mobile navigation
-        setTimeout(() => {
-          this.navCtrl.push(CoinbasePage, { coin: 'btc' }, { animate: false });
-        }, 200);
-      });
-    });
-
     modal.onDidDismiss(async () => {
       await this.navCtrl.popToRoot({ animate: false });
       await this.navCtrl.parent.select(0);

--- a/src/pages/integrations/coinbase/sell-coinbase/sell-coinbase.ts
+++ b/src/pages/integrations/coinbase/sell-coinbase/sell-coinbase.ts
@@ -396,6 +396,12 @@ export class SellCoinbasePage {
         }, 200);
       });
     });
+
+    modal.onDidDismiss(async () => {
+      await this.navCtrl.popToRoot({ animate: false });
+      await this.navCtrl.parent.select(0);
+      await this.navCtrl.push(CoinbasePage, { coin: 'btc' }, { animate: false });
+    });
   }
 
 }

--- a/src/pages/integrations/glidera/buy-glidera/buy-glidera.ts
+++ b/src/pages/integrations/glidera/buy-glidera/buy-glidera.ts
@@ -223,15 +223,10 @@ export class BuyGlideraPage {
     let finishComment = 'A transfer has been initiated from your bank account. Your bitcoins should arrive to your wallet in 2-4 business day';
     let modal = this.modalCtrl.create(FinishModalPage, { finishText, finishComment }, { showBackdrop: true, enableBackdropDismiss: false });
     modal.present();
-    modal.onDidDismiss(() => {
-      this.navCtrl.popToRoot({ animate: false }).then(() => {
-        this.navCtrl.parent.select(0);
-
-        // Fixes mobile navigation
-        setTimeout(() => {
-          this.navCtrl.push(GlideraPage, null, { animate: false });
-        }, 200);
-      });
+    modal.onDidDismiss(async () => {
+      await this.navCtrl.popToRoot({ animate: false });
+      await this.navCtrl.parent.select(0);
+      await this.navCtrl.push(GlideraPage, null, { animate: false });
     });
   }
 }

--- a/src/pages/integrations/glidera/sell-glidera/sell-glidera.ts
+++ b/src/pages/integrations/glidera/sell-glidera/sell-glidera.ts
@@ -290,15 +290,10 @@ export class SellGlideraPage {
     let finishComment = 'The transaction is not yet confirmed, and will show as "Pending" in your Activity. The bitcoin sale will be completed automatically once it is confirmed by Glidera';
     let modal = this.modalCtrl.create(FinishModalPage, { finishText, finishComment }, { showBackdrop: true, enableBackdropDismiss: false });
     modal.present();
-    modal.onDidDismiss(() => {
-      this.navCtrl.popToRoot({ animate: false }).then(() => {
-        this.navCtrl.parent.select(0);
-
-        // Fixes mobile navigation
-        setTimeout(() => {
-          this.navCtrl.push(GlideraPage, null, { animate: false });
-        }, 200);
-      });
+    modal.onDidDismiss(async () => {
+      await this.navCtrl.popToRoot({ animate: false });
+      await this.navCtrl.parent.select(0);
+      await this.navCtrl.push(GlideraPage, null, { animate: false });
     });
   }
 

--- a/src/pages/integrations/mercado-libre/buy-mercado-libre/buy-mercado-libre.ts
+++ b/src/pages/integrations/mercado-libre/buy-mercado-libre/buy-mercado-libre.ts
@@ -481,15 +481,10 @@ export class BuyMercadoLibrePage {
     let finishText = '';
     let modal = this.modalCtrl.create(FinishModalPage, { finishText, finishComment, cssClass }, { showBackdrop: true, enableBackdropDismiss: false });
     modal.present();
-    modal.onDidDismiss(() => {
-      this.navCtrl.popToRoot({ animate: false }).then(() => {
-        this.navCtrl.parent.select(0);
-
-        // Fixes mobile navigation
-        setTimeout(() => {
-          this.navCtrl.push(MercadoLibrePage, { invoiceId: this.invoiceId }, { animate: false });
-        }, 200);
-      });
+    modal.onDidDismiss(async () => {
+      await this.navCtrl.popToRoot({ animate: false });
+      await this.navCtrl.parent.select(0);
+      await this.navCtrl.push(MercadoLibrePage, { invoiceId: this.invoiceId }, { animate: false });
     });
   }
 

--- a/src/pages/integrations/shapeshift/shapeshift-confirm/shapeshift-confirm.ts
+++ b/src/pages/integrations/shapeshift/shapeshift-confirm/shapeshift-confirm.ts
@@ -244,18 +244,38 @@ export class ShapeshiftConfirmPage {
   private setFiatTotalAmount(amountSat: number, feeSat: number, withdrawalSat: number) {
     this.satToFiat(this.toWallet.coin, withdrawalSat, this.currencyIsoCode).then((w: any) => {
       this.fiatWithdrawal = Number(w);
-
       this.satToFiat(this.fromWallet.coin, amountSat, this.currencyIsoCode).then((a: any) => {
         this.fiatAmount = Number(a);
-
         this.satToFiat(this.fromWallet.coin, feeSat, this.currencyIsoCode).then((i: any) => {
           this.fiatFee = Number(i);
-
           this.fiatTotalAmount = this.fiatAmount + this.fiatFee;
         });
       });
     });
   }
+
+  // private setFiatTotalAmount(amountSat: number, feeSat: number, withdrawalSat: number): Promise<void> {
+  //   return this.satToFiat(this.toWallet.coin, withdrawalSat, this.currencyIsoCode).then((w: any) => {
+  //     this.fiatWithdrawal = Number(w);
+  //     return this.satToFiat(this.fromWallet.coin, amountSat, this.currencyIsoCode);
+  //   }).then((a: any) => {
+  //     this.fiatAmount = Number(a);
+  //     return this.satToFiat(this.fromWallet.coin, feeSat, this.currencyIsoCode);
+  //   }).then((i: any) => {
+  //     this.fiatFee = Number(i);
+  //     this.fiatTotalAmount = this.fiatAmount + this.fiatFee;
+  //   });
+  // }
+
+  // private async setFiatTotalAmount(amountSat: number, feeSat: number, withdrawalSat: number): Promise<void> {
+  //   const w = await this.satToFiat(this.toWallet.coin, withdrawalSat, this.currencyIsoCode);
+  //   this.fiatWithdrawal = Number(w);
+  //   const a = await this.satToFiat(this.fromWallet.coin, amountSat, this.currencyIsoCode);
+  //   this.fiatAmount = Number(a);
+  //   const i = await this.satToFiat(this.fromWallet.coin, feeSat, this.currencyIsoCode);
+  //   this.fiatFee = Number(i);
+  //   this.fiatTotalAmount = this.fiatAmount + this.fiatFee;
+  // }
 
   private saveShapeshiftData(): void {
     let address = this.shapeInfo.deposit;
@@ -474,15 +494,10 @@ export class ShapeshiftConfirmPage {
     let finishText = 'Transaction Sent';
     let modal = this.modalCtrl.create(FinishModalPage, { finishText }, { showBackdrop: true, enableBackdropDismiss: false });
     modal.present();
-    modal.onDidDismiss(() => {
-      this.navCtrl.popToRoot({ animate: false }).then(() => {
-        this.navCtrl.parent.select(0);
-
-        // Fixes mobile navigation
-        setTimeout(() => {
-          this.navCtrl.push(ShapeshiftPage, null, { animate: false });
-        }, 200);
-      });
+    modal.onDidDismiss(async () => {
+      await this.navCtrl.popToRoot({ animate: false });
+      await this.navCtrl.parent.select(0);
+      await this.navCtrl.push(ShapeshiftPage, null, { animate: false });
     });
   }
 

--- a/src/pages/integrations/shapeshift/shapeshift-confirm/shapeshift-confirm.ts
+++ b/src/pages/integrations/shapeshift/shapeshift-confirm/shapeshift-confirm.ts
@@ -254,29 +254,6 @@ export class ShapeshiftConfirmPage {
     });
   }
 
-  // private setFiatTotalAmount(amountSat: number, feeSat: number, withdrawalSat: number): Promise<void> {
-  //   return this.satToFiat(this.toWallet.coin, withdrawalSat, this.currencyIsoCode).then((w: any) => {
-  //     this.fiatWithdrawal = Number(w);
-  //     return this.satToFiat(this.fromWallet.coin, amountSat, this.currencyIsoCode);
-  //   }).then((a: any) => {
-  //     this.fiatAmount = Number(a);
-  //     return this.satToFiat(this.fromWallet.coin, feeSat, this.currencyIsoCode);
-  //   }).then((i: any) => {
-  //     this.fiatFee = Number(i);
-  //     this.fiatTotalAmount = this.fiatAmount + this.fiatFee;
-  //   });
-  // }
-
-  // private async setFiatTotalAmount(amountSat: number, feeSat: number, withdrawalSat: number): Promise<void> {
-  //   const w = await this.satToFiat(this.toWallet.coin, withdrawalSat, this.currencyIsoCode);
-  //   this.fiatWithdrawal = Number(w);
-  //   const a = await this.satToFiat(this.fromWallet.coin, amountSat, this.currencyIsoCode);
-  //   this.fiatAmount = Number(a);
-  //   const i = await this.satToFiat(this.fromWallet.coin, feeSat, this.currencyIsoCode);
-  //   this.fiatFee = Number(i);
-  //   this.fiatTotalAmount = this.fiatAmount + this.fiatFee;
-  // }
-
   private saveShapeshiftData(): void {
     let address = this.shapeInfo.deposit;
     let withdrawal = this.shapeInfo.withdrawal;

--- a/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-transaction-history/wallet-transaction-history.ts
+++ b/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-transaction-history/wallet-transaction-history.ts
@@ -16,7 +16,7 @@ import { WalletDetailsPage } from '../../../../../pages/wallet-details/wallet-de
 
 @Component({
   selector: 'page-wallet-transaction-history',
-  templateUrl: 'wallet-transaction-history.html',
+  templateUrl: 'wallet-transaction-history.html'
 })
 export class WalletTransactionHistoryPage {
   public wallet: any;
@@ -70,85 +70,103 @@ export class WalletTransactionHistoryPage {
     var dateObj = new Date(date);
     if (!dateObj) {
       this.logger.debug('Error formating a date');
-      return 'DateError'
+      return 'DateError';
     }
     if (!dateObj.toJSON()) {
       return '';
     }
     return dateObj.toJSON();
-  };
+  }
 
   // TODO : move this to walletService.
   public csvHistory() {
     this.logger.debug('Generating CSV from History');
-    this.walletProvider.getTxHistory(this.wallet, {}).then((txs: any) => {
-      if (_.isEmpty(txs)) {
-        this.logger.warn('Failed to generate CSV: no transactions');
-        this.err = 'no transactions';
-        return;
-      }
+    this.walletProvider
+      .getTxHistory(this.wallet, {})
+      .then((txs: any) => {
+        if (_.isEmpty(txs)) {
+          this.logger.warn('Failed to generate CSV: no transactions');
+          this.err = 'no transactions';
+          return;
+        }
 
-      this.logger.debug('Wallet Transaction History Length:', txs.length);
+        this.logger.debug('Wallet Transaction History Length:', txs.length);
 
-      var data = txs;
-      this.csvFilename = this.appName + '-' + this.wallet.name + '.csv';
-      this.csvHeader = ['Date', 'Destination', 'Description', 'Amount', 'Currency', 'Txid', 'Creator', 'Copayers', 'Comment'];
+        var data = txs;
+        this.csvFilename = this.appName + '-' + this.wallet.name + '.csv';
+        this.csvHeader = [
+          'Date',
+          'Destination',
+          'Description',
+          'Amount',
+          'Currency',
+          'Txid',
+          'Creator',
+          'Copayers',
+          'Comment'
+        ];
 
-      var _amount, _note, _copayers, _creator, _comment;
+        var _amount, _note, _copayers, _creator, _comment;
 
-      data.forEach((it, index) => {
-        var amount = it.amount;
+        data.forEach((it, index) => {
+          var amount = it.amount;
 
-        if (it.action == 'moved')
-          amount = 0;
+          if (it.action == 'moved') amount = 0;
 
-        _copayers = '';
-        _creator = '';
+          _copayers = '';
+          _creator = '';
 
-        if (it.actions && it.actions.length > 1) {
-          for (var i = 0; i < it.actions.length; i++) {
-            _copayers += it.actions[i].copayerName + ':' + it.actions[i].type + ' - ';
+          if (it.actions && it.actions.length > 1) {
+            for (var i = 0; i < it.actions.length; i++) {
+              _copayers +=
+                it.actions[i].copayerName + ':' + it.actions[i].type + ' - ';
+            }
+            _creator =
+              it.creatorName && it.creatorName != 'undefined'
+                ? it.creatorName
+                : '';
           }
-          _creator = (it.creatorName && it.creatorName != 'undefined') ? it.creatorName : '';
-        }
-        _amount = (it.action == 'sent' ? '-' : '') + (amount * this.satToBtc).toFixed(8);
-        _note = it.message || '';
-        _comment = it.note ? it.note.body : '';
+          _amount =
+            (it.action == 'sent' ? '-' : '') +
+            (amount * this.satToBtc).toFixed(8);
+          _note = it.message || '';
+          _comment = it.note ? it.note.body : '';
 
-        if (it.action == 'moved')
-          _note += ' Moved:' + (it.amount * this.satToBtc).toFixed(8)
+          if (it.action == 'moved')
+            _note += ' Moved:' + (it.amount * this.satToBtc).toFixed(8);
 
-        this.csvContent.push({
-          'Date': this.formatDate(it.time * 1000),
-          'Destination': it.addressTo || '',
-          'Description': _note,
-          'Amount': _amount,
-          'Currency': this.currency,
-          'Txid': it.txid,
-          'Creator': _creator,
-          'Copayers': _copayers,
-          'Comment': _comment
-        });
-
-        if (it.fees && (it.action == 'moved' || it.action == 'sent')) {
-          var _fee = (it.fees * this.satToBtc).toFixed(8)
           this.csvContent.push({
-            'Date': this.formatDate(it.time * 1000),
-            'Destination': 'Bitcoin Network Fees',
-            'Description': '',
-            'Amount': '-' + _fee,
-            'Currency': this.currency,
-            'Txid': '',
-            'Creator': '',
-            'Copayers': ''
+            Date: this.formatDate(it.time * 1000),
+            Destination: it.addressTo || '',
+            Description: _note,
+            Amount: _amount,
+            Currency: this.currency,
+            Txid: it.txid,
+            Creator: _creator,
+            Copayers: _copayers,
+            Comment: _comment
           });
-        }
+
+          if (it.fees && (it.action == 'moved' || it.action == 'sent')) {
+            var _fee = (it.fees * this.satToBtc).toFixed(8);
+            this.csvContent.push({
+              Date: this.formatDate(it.time * 1000),
+              Destination: 'Bitcoin Network Fees',
+              Description: '',
+              Amount: '-' + _fee,
+              Currency: this.currency,
+              Txid: '',
+              Creator: '',
+              Copayers: ''
+            });
+          }
+        });
+        this.csvReady = true;
+      })
+      .catch(err => {
+        this.logger.warn('Failed to generate CSV:', err);
+        this.err = err;
       });
-      this.csvReady = true;
-    }).catch((err) => {
-      this.logger.warn('Failed to generate CSV:', err);
-      this.err = err;
-    });
   }
 
   public downloadCSV() {
@@ -158,7 +176,7 @@ export class WalletTransactionHistoryPage {
     });
 
     var blob = new Blob([csv]);
-    var a = window.document.createElement("a");
+    var a = window.document.createElement('a');
     a.href = window.URL.createObjectURL(blob);
     a.download = this.csvFilename;
     document.body.appendChild(a);
@@ -166,20 +184,15 @@ export class WalletTransactionHistoryPage {
     document.body.removeChild(a);
   }
 
-  public clearTransactionHistory(): void {
+  public async clearTransactionHistory(): Promise<void> {
     this.logger.info('Removing Transaction history ' + this.wallet.id);
-
     this.walletProvider.clearTxHistory(this.wallet);
-
     this.logger.info('Transaction history cleared for :' + this.wallet.id);
-
-    this.navCtrl.popToRoot({ animate: false }).then(() => {
-      this.navCtrl.parent.select(0);
-      // Fixes mobile navigation
-      setTimeout(() => {
-        this.navCtrl.push(WalletDetailsPage, { walletId: this.wallet.credentials.walletId, clearCache: true });
-      }, 200);
+    await this.navCtrl.popToRoot({ animate: false });
+    await this.navCtrl.parent.select(0);
+    await this.navCtrl.push(WalletDetailsPage, {
+      walletId: this.wallet.credentials.walletId,
+      clearCache: true
     });
   }
-
 }


### PR DESCRIPTION
Currently, any time `this.navCtrl.parent.select(0)` is used in the codebase, a `setTimeout` wraps the subsequent `this.navCtrl.push(NewPage)` call to ensure the page `push` only occurs after the tab select has completed. However, `this.navCtrl.parent.select(0)` returns a promise that can be awaited to improve performance, reliability, and code maintainability. This refactor replaces such instances of `setTimeout` with promises.