### PR TITLE
Fix: bchtest prefix for BCH testnet wallets

### DIFF
--- a/src/providers/wallet/wallet.spec.ts
+++ b/src/providers/wallet/wallet.spec.ts
@@ -40,7 +40,7 @@ describe('Provider: Wallet Provider', () => {
   let walletProvider: WalletProvider;
 
   class PersistenceProviderMock {
-    constructor() {}
+    constructor() { }
     getLastAddress(walletId: any) {
       return Promise.resolve('storedAddress');
     }
@@ -150,7 +150,7 @@ describe('Provider: Wallet Provider', () => {
           return true;
         },
         needsBackup: false,
-        createAddress({}, cb) {
+        createAddress({ }, cb) {
           return cb(null, { address: 'newAddress' });
         }
       };
@@ -166,7 +166,7 @@ describe('Provider: Wallet Provider', () => {
           return true;
         },
         needsBackup: false,
-        createAddress({}, cb) {
+        createAddress({ }, cb) {
           return cb(new Error('CONNECTION_ERROR'));
         }
       };
@@ -181,10 +181,10 @@ describe('Provider: Wallet Provider', () => {
           return true;
         },
         needsBackup: false,
-        createAddress({}, cb) {
+        createAddress({ }, cb) {
           return cb(new Error('MAIN_ADDRESS_GAP_REACHED'));
         },
-        getMainAddresses({}, cb) {
+        getMainAddresses({ }, cb) {
           let mainAddress = [];
           mainAddress.push({ address: 'mainAddress' });
           return cb(null, mainAddress);
@@ -198,10 +198,18 @@ describe('Provider: Wallet Provider', () => {
   });
 
   describe('Function: Get Protocol Handler Function', () => {
-    it('should return bitcoincash if coin is bch', () => {
+    it('should return bitcoincash if coin is bch and network is livenet', () => {
       let coin = 'bch';
-      let protocol = walletProvider.getProtocolHandler(coin);
+      let network = 'livenet';
+      let protocol = walletProvider.getProtocolHandler(coin, network);
       expect(protocol).toEqual('bitcoincash');
+    });
+
+    it('should return bchtest if coin is bch and network is testnet', () => {
+      let coin = 'bch';
+      let network = 'testnet';
+      let protocol = walletProvider.getProtocolHandler(coin, network);
+      expect(protocol).toEqual('bchtest');
     });
 
     it('should return bitcoin if coin is btc', () => {

--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -336,7 +336,7 @@ export class WalletProvider {
   }
 
   public getProtoAddress(wallet: any, address: string) {
-    let proto: string = this.getProtocolHandler(wallet.coin);
+    let proto: string = this.getProtocolHandler(wallet.coin, wallet.network);
     let protoAddr: string = proto + ':' + address;
 
     if (wallet.coin != 'bch' || this.useLegacyAddress()) {
@@ -1331,9 +1331,9 @@ export class WalletProvider {
     });
   }
 
-  public getProtocolHandler(coin: string): string {
+  public getProtocolHandler(coin: string, network?: string): string {
     if (coin == 'bch') {
-      return 'bitcoincash';
+      return network == 'testnet' ? 'bchtest' : 'bitcoincash';
     } else {
       return 'bitcoin';
     }


### PR DESCRIPTION
*Waiting for the bitcore-lib-cash fix to complete the flow with the prefix of BCH testnet