### PR TITLE
Fix: Ensure moved icon displays properly

### DIFF
--- a/src/pages/wallet-details/wallet-details.html
+++ b/src/pages/wallet-details/wallet-details.html
@@ -154,7 +154,8 @@
                 </div>
                 <div *ngIf="tx.confirmations > 0">
                   <span *ngIf="tx.customData && tx.customData.service">
-                    <img class="icon-services" src="assets/img/shapeshift/icon-shapeshift.svg" *ngIf="tx.customData.service == 'shapeshift'" width="40">
+                    <img class="icon-services" src="assets/img/shapeshift/icon-shapeshift.svg" *ngIf="tx.customData.service == 'shapeshift'"
+                      width="40">
                     <img class="icon-services" src="assets/img/amazon/icon-amazon.svg" *ngIf="tx.customData.service == 'amazon'" width="40">
                     <img class="icon-services" src="assets/img/mercado-libre/icon-ml.svg" *ngIf="tx.customData.service == 'mercadolibre'" width="40">
                     <img class="icon-services" src="assets/img/bitpay-card/icon-bitpay.svg" *ngIf="tx.customData.service == 'debitcard'" width="40">
@@ -162,7 +163,7 @@
                   <span *ngIf="tx.customData && tx.customData.toWalletName && !tx.customData.service">
                     <img class="icon-services" src="assets/img/icon-wallet-reverse.svg" *ngIf="tx.action == 'sent'" width="40">
                   </span>
-                  <span *ngIf="!tx.customData || (tx.customData && !tx.customData.service && !tx.customData.toWalletName)">
+                  <span *ngIf="!tx.customData || (tx.customData && !tx.customData.service && (!tx.customData.toWalletName || tx.customData.toWalletName === wallet.name))">
                     <img src="assets/img/tx-action/icon-received.svg" *ngIf="tx.action == 'received'" width="40">
                     <img src="assets/img/tx-action/icon-sent.svg" *ngIf="tx.action == 'sent'" width="40">
                     <img src="assets/img/tx-action/icon-moved.svg" *ngIf="tx.action == 'moved'" width="40">


### PR DESCRIPTION
Currently the "moved" icon is not being shown in transaction history (just an empty spot). This PR ensures the moved icon is properly displayed.