### PR TITLE
change fee message to percentage of amount sent

### DIFF
--- a/src/pages/send/confirm/confirm.html
+++ b/src/pages/send/confirm/confirm.html
@@ -36,7 +36,7 @@
             <span [ngClass]="{'warn':tx.txp[wallet.id].feeTooHigh}">
               <ion-icon *ngIf="tx.txp[wallet.id].feeTooHigh" name="warning"></ion-icon>
               {{tx.txp[wallet.id].feeRatePerStr}}
-              <span translate> of total amount</span>
+              <span translate> of sending amount</span>
             </span>
           </span>
         </div>

--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -504,7 +504,7 @@ export class ConfirmPage {
     return new Promise((resolve, reject) => {
       this.getTxp(_.clone(tx), wallet, opts.dryRun)
         .then(txp => {
-          let per = (txp.fee / (txp.amount + txp.fee)) * 100;
+          let per = (txp.fee / txp.amount) * 100;
           txp.feeRatePerStr = per.toFixed(2) + '%';
           txp.feeTooHigh = per > this.FEE_TOO_HIGH_LIMIT_PER;
 


### PR DESCRIPTION
It makes more sense to have the fee percentage shown on the confirm page to be a percentage of the amount you are sending, not total amount. If I am sending 1 BTC and the network fee is 0.5 BTC the percentage should be 50% not 33%. It is costing me an additional 50% of what I'm trying to send to pay a sufficient fee.