### PR TITLE
Ignore currency selector if within wallet

### DIFF
--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -220,6 +220,9 @@ export class ConfirmPage extends WalletTabsChild {
     network: string,
     minAmount: number
   ): Promise<any> {
+    if (this.getParentWallet()) {
+      return Promise.resolve();
+    }
     return new Promise((resolve, reject) => {
       // no min amount? (sendMax) => look for no empty wallets
       minAmount = minAmount ? minAmount : 1;


### PR DESCRIPTION
Bypasses the `setCurrencySelector` method in `confirm.ts` if the payment was initiated from within a wallet, since the wallet is  already implicitly set.