### PR TITLE
Fix send max bugs when scanning a qr code

### DIFF
--- a/src/pages/send/amount/amount.spec.ts
+++ b/src/pages/send/amount/amount.spec.ts
@@ -47,5 +47,11 @@ describe('AmountPage', () => {
       expect(spy).toHaveBeenCalledWith(100000000, 'USD', Coin.BCH);
       expect(instance.expression).toBe('1000000.00');
     });
+
+    it('should skip rate calculations and go directly to confirm if not within wallet', () => {
+      const spy = spyOn(instance, 'finish');
+      instance.sendMax();
+      expect(spy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/pages/send/amount/amount.ts
+++ b/src/pages/send/amount/amount.ts
@@ -302,6 +302,9 @@ export class AmountPage extends WalletTabsChild {
 
   public sendMax(): void {
     this.useSendMax = true;
+    if (!this.getParentWallet()) {
+      return this.finish();
+    }
     const maxAmount = this.wallet.status.totalBalanceStr.replace(
       /[^0-9.]/g,
       ''

--- a/src/pages/send/amount/amount.ts
+++ b/src/pages/send/amount/amount.ts
@@ -177,8 +177,7 @@ export class AmountPage extends WalletTabsChild {
   private setAvailableUnits(): void {
     this.availableUnits = [];
 
-    const parentWalletCoin =
-      this.getParentWallet() && this.getParentWallet().coin;
+    const parentWalletCoin = this.wallet && this.wallet.coin;
 
     if (parentWalletCoin === 'btc' || !parentWalletCoin) {
       this.availableUnits.push({
@@ -302,7 +301,7 @@ export class AmountPage extends WalletTabsChild {
 
   public sendMax(): void {
     this.useSendMax = true;
-    if (!this.getParentWallet()) {
+    if (!this.wallet) {
       return this.finish();
     }
     const maxAmount = this.wallet.status.totalBalanceStr.replace(

--- a/src/pages/send/send.spec.ts
+++ b/src/pages/send/send.spec.ts
@@ -34,7 +34,7 @@ describe('SendPage', () => {
   });
 
   describe('openScanner', () => {
-    it('should set the send display value expression to the total balance', () => {
+    it('should pass the pre-selected amount, coin, and sendMax values to the scanner', () => {
       const walletTabsProvider: WalletTabsProvider = testBed.get(
         WalletTabsProvider
       );

--- a/src/pages/send/send.spec.ts
+++ b/src/pages/send/send.spec.ts
@@ -1,0 +1,58 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Events, NavParams } from 'ionic-angular';
+
+import { Coin } from '../../providers/wallet/wallet';
+import { TestUtils } from '../../test';
+import { WalletTabsChild } from '../wallet-tabs/wallet-tabs-child';
+import { WalletTabsProvider } from '../wallet-tabs/wallet-tabs.provider';
+import { SendPage } from './send';
+
+describe('SendPage', () => {
+  let fixture: ComponentFixture<SendPage>;
+  let instance;
+  let testBed: typeof TestBed;
+
+  const wallet = {
+    coin: 'bch',
+    status: {
+      totalBalanceStr: '1.000000'
+    }
+  };
+
+  beforeEach(async(() => {
+    spyOn(WalletTabsChild.prototype, 'getParentWallet').and.returnValue(wallet);
+    TestUtils.configurePageTestingModule([SendPage]).then(testEnv => {
+      fixture = testEnv.fixture;
+      instance = testEnv.instance;
+      instance.wallet = wallet;
+      testBed = testEnv.testBed;
+      fixture.detectChanges();
+    });
+  }));
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  describe('openScanner', () => {
+    it('should set the send display value expression to the total balance', () => {
+      const walletTabsProvider: WalletTabsProvider = testBed.get(
+        WalletTabsProvider
+      );
+      const events: Events = testBed.get(Events);
+      const navParams: NavParams = testBed.get(NavParams);
+      const amount = '1.00000';
+      const coin = Coin.BCH;
+      instance.useSendMax = false;
+      spyOn(navParams, 'get').and.returnValues(amount, coin);
+      const sendParamsSpy = spyOn(walletTabsProvider, 'setSendParams');
+      const publishSpy = spyOn(events, 'publish');
+      instance.openScanner();
+      expect(sendParamsSpy).toHaveBeenCalledWith({
+        amount,
+        coin,
+        useSendMax: false
+      });
+      expect(publishSpy).toHaveBeenCalledWith('ScanFromWallet');
+    });
+  });
+});

--- a/src/pages/send/send.ts
+++ b/src/pages/send/send.ts
@@ -77,10 +77,6 @@ export class SendPage extends WalletTabsChild {
   }
 
   ionViewDidLoad() {
-    this.walletTabsProvider.setSendParams({
-      amount: this.navParams.get('amount'),
-      coin: this.navParams.get('coin')
-    });
     this.amount = this.txFormatProvider.formatAmountStr(
       this.navParams.get('coin'),
       parseInt(this.navParams.get('amount'), 10)
@@ -220,6 +216,11 @@ export class SendPage extends WalletTabsChild {
   }
 
   public openScanner(): void {
+    this.walletTabsProvider.setSendParams({
+      amount: this.navParams.get('amount'),
+      coin: this.navParams.get('coin'),
+      useSendMax: this.useSendMax
+    });
     this.events.publish('ScanFromWallet');
   }
 

--- a/src/pages/wallet-tabs/wallet-tabs.provider.ts
+++ b/src/pages/wallet-tabs/wallet-tabs.provider.ts
@@ -5,6 +5,7 @@ import { Coin } from '../../providers/wallet/wallet';
 export interface SendParams {
   amount: string;
   coin: Coin;
+  useSendMax: boolean;
 }
 
 @Injectable()

--- a/src/providers/incoming-data/incoming-data.spec.ts
+++ b/src/providers/incoming-data/incoming-data.spec.ts
@@ -224,7 +224,8 @@ describe('Provider: Incoming Data Provider', () => {
             amount,
             toAddress: addr,
             description: message,
-            coin: 'btc'
+            coin: 'btc',
+            useSendMax: false
           };
           let nextView = {
             name: 'ConfirmPage',

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -53,7 +53,7 @@ export class IncomingDataProvider {
           this.handlePayPro(details, coin);
         })
         .catch(err => {
-          this.popupProvider.ionicAlert(this.translate.instant('Error'), err);
+          this.showError(err);
         });
 
       return true;
@@ -84,10 +84,7 @@ export class IncomingDataProvider {
           .catch((err: string) => {
             addr && amount
               ? this.goSend(addr, amount, message, coin, useSendMax)
-              : this.popupProvider.ionicAlert(
-                  this.translate.instant('Error'),
-                  err
-                );
+              : this.showError(err);
           });
       } else {
         this.goSend(addr, amount, message, coin, useSendMax);
@@ -117,10 +114,7 @@ export class IncomingDataProvider {
           .catch((err: string) => {
             addr && amount
               ? this.goSend(addr, amount, message, coin, useSendMax)
-              : this.popupProvider.ionicAlert(
-                  this.translate.instant('Error'),
-                  err
-                );
+              : this.showError(err);
           });
       } else {
         this.goSend(addr, amount, message, coin, useSendMax);
@@ -175,10 +169,7 @@ export class IncomingDataProvider {
             .catch(err => {
               addr && amount
                 ? this.goSend(addr, amount, message, coin, useSendMax)
-                : this.popupProvider.ionicAlert(
-                    this.translate.instant('Error'),
-                    err
-                  );
+                : this.showError(err);
             });
         } else {
           this.goSend(addr, amount, message, coin, useSendMax);
@@ -437,12 +428,16 @@ export class IncomingDataProvider {
     this.events.publish('IncomingDataRedir', nextView);
   }
 
+  private showError(message: string) {
+    return this.popupProvider.ionicAlert(
+      this.translate.instant('Error'),
+      this.translate.instant(message)
+    );
+  }
+
   private handlePayPro(payProDetails, coin?: Coin): void {
     if (!payProDetails) {
-      this.popupProvider.ionicAlert(
-        this.translate.instant('Error'),
-        this.translate.instant('No wallets available')
-      );
+      this.showError('No wallets available');
       return;
     }
 

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -36,7 +36,7 @@ export class IncomingDataProvider {
   }
 
   public redir(data: string, redirParams?: RedirParams): boolean {
-    const useSendMax = redirParams && redirParams.useSendMax;
+    const useSendMax = redirParams && redirParams.useSendMax ? true : false;
     // data extensions for Payment Protocol with non-backwards-compatible request
     if (/^bitcoin(cash)?:\?r=[\w+]/.exec(data)) {
       this.logger.debug(

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -43,7 +43,7 @@ export class IncomingDataProvider {
         'Handling Payment Protocol with non-backwards-compatible request'
       );
 
-      let coin = data.indexOf('bitcoincash') === 0 ? 'bch' : 'btc';
+      let coin = data.indexOf('bitcoincash') === 0 ? Coin.BCH : Coin.BTC;
 
       data = decodeURIComponent(data.replace(/bitcoin(cash)?:\?r=/, ''));
 
@@ -64,12 +64,12 @@ export class IncomingDataProvider {
     let message: string;
     let addr: string;
     let parsed;
-    let coin: string;
+    let coin: Coin;
 
     // Bitcoin  URL
     if (this.bwcProvider.getBitcore().URI.isValid(data)) {
       this.logger.debug('Handling Bitcoin URI');
-      coin = 'btc';
+      coin = Coin.BTC;
       parsed = this.bwcProvider.getBitcore().URI(data);
       addr = parsed.address ? parsed.address.toString() : '';
       message = parsed.message;
@@ -82,13 +82,12 @@ export class IncomingDataProvider {
             this.handlePayPro(details, coin);
           })
           .catch((err: string) => {
-            if (addr && amount)
-              this.goSend(addr, amount, message, coin, useSendMax);
-            else
-              this.popupProvider.ionicAlert(
-                this.translate.instant('Error'),
-                err
-              );
+            addr && amount
+              ? this.goSend(addr, amount, message, coin, useSendMax)
+              : this.popupProvider.ionicAlert(
+                  this.translate.instant('Error'),
+                  err
+                );
           });
       } else {
         this.goSend(addr, amount, message, coin, useSendMax);
@@ -97,7 +96,7 @@ export class IncomingDataProvider {
       // Cash URI
     } else if (this.bwcProvider.getBitcoreCash().URI.isValid(data)) {
       this.logger.debug('Handling Bitcoin Cash URI');
-      coin = 'bch';
+      coin = Coin.BCH;
       parsed = this.bwcProvider.getBitcoreCash().URI(data);
       addr = parsed.address ? parsed.address.toString() : '';
 
@@ -116,13 +115,12 @@ export class IncomingDataProvider {
             this.handlePayPro(details, coin);
           })
           .catch((err: string) => {
-            if (addr && amount)
-              this.goSend(addr, amount, message, coin, useSendMax);
-            else
-              this.popupProvider.ionicAlert(
-                this.translate.instant('Error'),
-                err
-              );
+            addr && amount
+              ? this.goSend(addr, amount, message, coin, useSendMax)
+              : this.popupProvider.ionicAlert(
+                  this.translate.instant('Error'),
+                  err
+                );
           });
       } else {
         this.goSend(addr, amount, message, coin, useSendMax);
@@ -136,7 +134,7 @@ export class IncomingDataProvider {
         .URI.isValid(data.replace(/^bitcoincash:/, 'bitcoin:'))
     ) {
       this.logger.debug('Handling Bitcoin Cash URI with legacy address');
-      coin = 'bch';
+      coin = Coin.BCH;
       parsed = this.bwcProvider
         .getBitcore()
         .URI(data.replace(/^bitcoincash:/, 'bitcoin:'));
@@ -175,13 +173,12 @@ export class IncomingDataProvider {
               this.handlePayPro(details, coin);
             })
             .catch(err => {
-              if (addr && amount)
-                this.goSend(addr, amount, message, coin, useSendMax);
-              else
-                this.popupProvider.ionicAlert(
-                  this.translate.instant('Error'),
-                  err
-                );
+              addr && amount
+                ? this.goSend(addr, amount, message, coin, useSendMax)
+                : this.popupProvider.ionicAlert(
+                    this.translate.instant('Error'),
+                    err
+                  );
             });
         } else {
           this.goSend(addr, amount, message, coin, useSendMax);
@@ -193,7 +190,7 @@ export class IncomingDataProvider {
       // Plain URL
       this.logger.debug('Handling Plain URL');
 
-      let coin = 'btc'; // Assume BTC
+      let coin = Coin.BTC; // Assume BTC
 
       this.payproProvider
         .getPayProDetails(data, coin, true)
@@ -213,7 +210,7 @@ export class IncomingDataProvider {
       this.bwcProvider.getBitcore().Address.isValid(data, 'testnet')
     ) {
       this.logger.debug('Handling Bitcoin Plain Address');
-      const coin = 'btc';
+      const coin = Coin.BTC;
       if (redirParams.activePage === 'ScanPage') {
         this.showMenu({
           data,
@@ -231,7 +228,7 @@ export class IncomingDataProvider {
       this.bwcProvider.getBitcoreCash().Address.isValid(data, 'testnet')
     ) {
       this.logger.debug('Handling Bitcoin Cash Plain Address');
-      const coin = 'bch';
+      const coin = Coin.BCH;
       if (redirParams.activePage === 'ScanPage') {
         this.showMenu({
           data,
@@ -398,7 +395,7 @@ export class IncomingDataProvider {
     addr: string,
     amount: string,
     message: string,
-    coin: string,
+    coin: Coin,
     useSendMax: boolean
   ): void {
     if (amount) {
@@ -428,7 +425,7 @@ export class IncomingDataProvider {
     }
   }
 
-  private goToAmountPage(toAddress: string, coin: string): void {
+  private goToAmountPage(toAddress: string, coin: Coin): void {
     let stateParams = {
       toAddress,
       coin
@@ -440,7 +437,7 @@ export class IncomingDataProvider {
     this.events.publish('IncomingDataRedir', nextView);
   }
 
-  private handlePayPro(payProDetails, coin?: string): void {
+  private handlePayPro(payProDetails, coin?: Coin): void {
     if (!payProDetails) {
       this.popupProvider.ionicAlert(
         this.translate.instant('Error'),

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -14,6 +14,7 @@ export interface RedirParams {
   activePage?: any;
   amount?: string;
   coin?: Coin;
+  useSendMax?: boolean;
 }
 
 @Injectable()
@@ -35,6 +36,7 @@ export class IncomingDataProvider {
   }
 
   public redir(data: string, redirParams?: RedirParams): boolean {
+    const useSendMax = redirParams && redirParams.useSendMax;
     // data extensions for Payment Protocol with non-backwards-compatible request
     if (/^bitcoin(cash)?:\?r=[\w+]/.exec(data)) {
       this.logger.debug(
@@ -80,7 +82,8 @@ export class IncomingDataProvider {
             this.handlePayPro(details, coin);
           })
           .catch((err: string) => {
-            if (addr && amount) this.goSend(addr, amount, message, coin);
+            if (addr && amount)
+              this.goSend(addr, amount, message, coin, useSendMax);
             else
               this.popupProvider.ionicAlert(
                 this.translate.instant('Error'),
@@ -88,7 +91,7 @@ export class IncomingDataProvider {
               );
           });
       } else {
-        this.goSend(addr, amount, message, coin);
+        this.goSend(addr, amount, message, coin, useSendMax);
       }
       return true;
       // Cash URI
@@ -113,7 +116,8 @@ export class IncomingDataProvider {
             this.handlePayPro(details, coin);
           })
           .catch((err: string) => {
-            if (addr && amount) this.goSend(addr, amount, message, coin);
+            if (addr && amount)
+              this.goSend(addr, amount, message, coin, useSendMax);
             else
               this.popupProvider.ionicAlert(
                 this.translate.instant('Error'),
@@ -121,7 +125,7 @@ export class IncomingDataProvider {
               );
           });
       } else {
-        this.goSend(addr, amount, message, coin);
+        this.goSend(addr, amount, message, coin, useSendMax);
       }
       return true;
 
@@ -171,7 +175,8 @@ export class IncomingDataProvider {
               this.handlePayPro(details, coin);
             })
             .catch(err => {
-              if (addr && amount) this.goSend(addr, amount, message, coin);
+              if (addr && amount)
+                this.goSend(addr, amount, message, coin, useSendMax);
               else
                 this.popupProvider.ionicAlert(
                   this.translate.instant('Error'),
@@ -179,7 +184,7 @@ export class IncomingDataProvider {
                 );
             });
         } else {
-          this.goSend(addr, amount, message, coin);
+          this.goSend(addr, amount, message, coin, useSendMax);
         }
         return undefined;
       });
@@ -216,7 +221,7 @@ export class IncomingDataProvider {
           coin
         });
       } else if (redirParams && redirParams.amount) {
-        this.goSend(data, redirParams.amount, '', coin);
+        this.goSend(data, redirParams.amount, '', coin, useSendMax);
       } else {
         this.goToAmountPage(data, coin);
       }
@@ -234,7 +239,7 @@ export class IncomingDataProvider {
           coin: 'bch'
         });
       } else if (redirParams && redirParams.amount) {
-        this.goSend(data, redirParams.amount, '', coin);
+        this.goSend(data, redirParams.amount, '', coin, useSendMax);
       } else {
         this.goToAmountPage(data, coin);
       }
@@ -393,14 +398,16 @@ export class IncomingDataProvider {
     addr: string,
     amount: string,
     message: string,
-    coin: string
+    coin: string,
+    useSendMax: boolean
   ): void {
     if (amount) {
       let stateParams = {
         amount,
         toAddress: addr,
         description: message,
-        coin
+        coin,
+        useSendMax
       };
       let nextView = {
         name: 'ConfirmPage',


### PR DESCRIPTION
Currently, scanning a bitcoin address either from the home view or from within a wallet breaks if the user chooses the send max option. This PR fixes this issue. 