### PR TITLE
Fix: Send Max behavior for wallets with locked balance

### DIFF
--- a/src/pages/receive/receive.html
+++ b/src/pages/receive/receive.html
@@ -13,7 +13,10 @@
     </ion-buttons>
   </ion-navbar>
   <ion-toolbar [navbar-bg]="wallet.color">
-    <div *ngIf="!wallet.balanceHidden && !wallet.scanning && wallet.status" class="wallet-details-header__balance">{{wallet.status && wallet.status.totalBalanceStr}}</div>
+    <div *ngIf="!wallet.balanceHidden && !wallet.scanning && wallet.status" class="wallet-details-header__balance">
+      <span>{{wallet.status && wallet.status.totalBalanceStr}}</span>
+      <ion-icon *ngIf="wallet.status.totalBalanceSat != wallet.status.spendableAmount" ios="ios-timer-outline" md="md-timer"></ion-icon>
+    </div>
     <div *ngIf="wallet.balanceHidden  && !wallet.scanning" class="wallet-details-header__balance-hidden">
       <span class="title" translate>[Balance Hidden]</span>
     </div>

--- a/src/pages/send/amount/amount.html
+++ b/src/pages/send/amount/amount.html
@@ -8,7 +8,10 @@
     <ion-title>{{wallet && wallet.name || ('Amount' | translate)}}</ion-title>
   </ion-navbar>
   <ion-toolbar *ngIf="wallet && !requestingAmount" [navbar-bg]="wallet.color">
-    <div *ngIf="!wallet.balanceHidden && !wallet.scanning && wallet.status" class="wallet-details-header__balance">{{wallet.status && wallet.status.totalBalanceStr}}</div>
+    <div *ngIf="!wallet.balanceHidden && !wallet.scanning && wallet.status" class="wallet-details-header__balance">
+      <span>{{wallet.status && wallet.status.totalBalanceStr}}</span>
+      <ion-icon *ngIf="wallet.status.totalBalanceSat != wallet.status.spendableAmount" ios="ios-timer-outline" md="md-timer"></ion-icon>
+    </div>
     <div *ngIf="wallet.balanceHidden  && !wallet.scanning" class="wallet-details-header__balance-hidden">
       <span class="title" translate>[Balance Hidden]</span>
     </div>

--- a/src/pages/send/amount/amount.spec.ts
+++ b/src/pages/send/amount/amount.spec.ts
@@ -13,7 +13,8 @@ describe('AmountPage', () => {
   const wallet = {
     coin: 'bch',
     status: {
-      totalBalanceStr: '1.000000'
+      totalBalanceStr: '1.000000',
+      availableBalanceStr: '1.000000'
     }
   };
 

--- a/src/pages/send/amount/amount.spec.ts
+++ b/src/pages/send/amount/amount.spec.ts
@@ -14,7 +14,9 @@ describe('AmountPage', () => {
     coin: 'bch',
     status: {
       totalBalanceStr: '1.000000',
-      availableBalanceStr: '1.000000'
+      totalBalanceSat: 100000000,
+      availableBalanceStr: '1.000000',
+      availableBalanceSat: 100000000
     }
   };
 
@@ -31,11 +33,13 @@ describe('AmountPage', () => {
   });
 
   describe('sendMax', () => {
-    it('should set the send display value expression to the total balance', () => {
+    it('should set the send display value expression to the available balance', () => {
       instance.wallet = wallet;
       instance.ionViewDidLoad();
       instance.sendMax();
-      expect(instance.expression).toBe(instance.wallet.status.totalBalanceStr);
+      expect(instance.expression).toBe(
+        instance.wallet.status.availableBalanceSat / 1e8
+      );
     });
 
     it('should fetch the bch rate if in bch wallet', () => {

--- a/src/pages/send/amount/amount.ts
+++ b/src/pages/send/amount/amount.ts
@@ -314,7 +314,7 @@ export class AmountPage extends WalletTabsChild {
     if (!this.wallet) {
       return this.finish();
     }
-    const maxAmount = this.wallet.status.totalBalanceStr.replace(
+    const maxAmount = this.wallet.status.availableBalanceStr.replace(
       /[^0-9.]/g,
       ''
     );
@@ -324,6 +324,7 @@ export class AmountPage extends WalletTabsChild {
         : maxAmount;
       this.processAmount();
       this.changeDetectorRef.detectChanges();
+      this.finish();
     });
   }
 

--- a/src/pages/send/amount/amount.ts
+++ b/src/pages/send/amount/amount.ts
@@ -314,9 +314,8 @@ export class AmountPage extends WalletTabsChild {
     if (!this.wallet) {
       return this.finish();
     }
-    const maxAmount = this.wallet.status.availableBalanceStr.replace(
-      /[^0-9.]/g,
-      ''
+    const maxAmount = this.txFormatProvider.satToUnit(
+      this.wallet.status.availableBalanceSat
     );
     this.zone.run(() => {
       this.expression = this.availableUnits[this.unitIndex].isFiat

--- a/src/pages/send/send.html
+++ b/src/pages/send/send.html
@@ -4,8 +4,11 @@
   </ion-navbar>
   <ion-toolbar [navbar-bg]="wallet.color">
     <div class="wallet-details-header__balance">
-      <span *ngIf="fiatCode === 'USD'">$</span>{{fiatAmount || amount}}
-      <span *ngIf="fiatCode !== 'USD'">{{fiatCode || coin}}</span>
+      <span *ngIf="!useSendMax">
+        <span *ngIf="fiatCode === 'USD'">$</span>{{fiatAmount || amount}}
+        <span *ngIf="fiatCode !== 'USD'">{{fiatCode || coin}}</span>
+      </span>
+      <span *ngIf="useSendMax">{{'Maximum Amount' | translate}}</span>
     </div>
   </ion-toolbar>
 </ion-header>
@@ -27,7 +30,7 @@
         <span class="title" translate>Transfer to Contact</span>
       </ion-item-divider>
       <ion-list>
-        <button ion-item *ngFor="let item of filteredContactsList" (click)="goToAmount(item)">
+        <button ion-item *ngFor="let item of filteredContactsList" (click)="goToConfirm(item)">
           <ion-icon class="item-img" item-start>
             <gravatar [name]="item.name" [width]="35" [height]="35" [email]="item.email"></gravatar>
           </ion-icon>
@@ -46,10 +49,12 @@
       </ion-item-divider>
 
       <ion-list>
-        <button ion-item *ngFor="let wallet of walletBtcList" (click)="goToAmount(wallet)">
+        <button ion-item *ngFor="let wallet of walletBtcList" (click)="goToConfirm(wallet)">
           <ion-icon class="item-img" item-start>
-            <img *ngIf="wallet.network == 'testnet'" [ngStyle]="{'background-color': wallet.color}" src="assets/img/icon-wallet-testnet.svg" class="icon-wallet" />
-            <img *ngIf="wallet.network != 'testnet'" [ngStyle]="{'background-color': wallet.color}" src="assets/img/icon-wallet.svg" class="icon-wallet" />
+            <img *ngIf="wallet.network == 'testnet'" [ngStyle]="{'background-color': wallet.color}" src="assets/img/icon-wallet-testnet.svg"
+              class="icon-wallet" />
+            <img *ngIf="wallet.network != 'testnet'" [ngStyle]="{'background-color': wallet.color}" src="assets/img/icon-wallet.svg"
+              class="icon-wallet" />
           </ion-icon>
           <span class="item-title">{{wallet.name}}</span>
           <ion-note class="wallet-warning" *ngIf="!wallet.isComplete" item-end>
@@ -72,10 +77,12 @@
       </ion-item-divider>
 
       <ion-list>
-        <button ion-item *ngFor="let wallet of walletBchList" (click)="goToAmount(wallet)">
+        <button ion-item *ngFor="let wallet of walletBchList" (click)="goToConfirm(wallet)">
           <ion-icon class="item-img" item-start>
-            <img *ngIf="wallet.network == 'testnet'" [ngStyle]="{'background-color': wallet.color}" src="assets/img/icon-wallet-testnet.svg" class="icon-wallet" />
-            <img *ngIf="wallet.network != 'testnet'" [ngStyle]="{'background-color': wallet.color}" src="assets/img/icon-wallet.svg" class="icon-wallet" />
+            <img *ngIf="wallet.network == 'testnet'" [ngStyle]="{'background-color': wallet.color}" src="assets/img/icon-wallet-testnet.svg"
+              class="icon-wallet" />
+            <img *ngIf="wallet.network != 'testnet'" [ngStyle]="{'background-color': wallet.color}" src="assets/img/icon-wallet.svg"
+              class="icon-wallet" />
           </ion-icon>
           <span class="item-title">{{wallet.name}}</span>
           <ion-note class="wallet-warning" *ngIf="!wallet.isComplete" item-end>

--- a/src/pages/send/send.ts
+++ b/src/pages/send/send.ts
@@ -228,7 +228,8 @@ export class SendPage extends WalletTabsChild {
     if (
       this.incomingDataProvider.redir(search, {
         amount: this.navParams.get('amount'),
-        coin: this.navParams.get('coin')
+        coin: this.navParams.get('coin'),
+        useSendMax: this.useSendMax
       })
     )
       return;
@@ -243,7 +244,7 @@ export class SendPage extends WalletTabsChild {
     }
   }
 
-  public goToAmount(item): void {
+  public goToConfirm(item): void {
     item
       .getAddress()
       .then((addr: string) => {

--- a/src/pages/wallet-details/wallet-details.scss
+++ b/src/pages/wallet-details/wallet-details.scss
@@ -269,5 +269,10 @@ page-wallet-details {
     padding-bottom: 10px;
     font-size: 18px;
     font-weight: 500;
+    ion-icon {
+      font-size: 16px;
+      font-weight: 100;
+      margin-left: 5px;
+    }
   }
 }


### PR DESCRIPTION
This PR fixes:

- Send maximum amount of a wallet with locked funds
- Receive view and Amount view now show the clock icon when the total balance is not spendable
- In Amount page, by clicking the "Send Max" button, redirect to the Send view directly
- Send Max is correctly calculated when trying to send to an address pasted in the input of the Send Page
- Miner fee now is set regardless of whether you click on "GOT IT" of the modal