### PR TITLE
Fix: styles for long strings when use different languages

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -28,6 +28,17 @@ ion-label {
   white-space: normal;
 }
 
+.two-lines {
+  white-space: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  box-orient: vertical;
+  -webkit-box-orient: vertical;
+}
+
 // Buttons
 // --------------------------------------------------
 .bottom-absolute {
@@ -341,7 +352,7 @@ ion-icon {
   max-width: 300px !important;
   margin-left: auto;
   margin-right: auto;
-  display: block;
+  display: flex;
   min-height: 57px;
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
@@ -349,6 +360,9 @@ ion-icon {
   box-shadow: none;
   font-weight: 400;
   font-size: 18px;
+  span {
+    @extend .two-lines;
+  }
 }
 
 .button-default {

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -160,11 +160,11 @@
 
       <div class="card" *ngIf="walletsBtc && walletsBtc[0]">
         <ion-item-divider>
-          <div class="title" item-start>
+          <div class="title wallets-list-title" item-start>
             <img src="assets/img/icon-bitcoin.svg" alt="Bitcoin Wallets" width="18" />
             <span translate>Bitcoin Wallets</span>
           </div>
-          <div item-end *ngIf="!showReorderBtc">
+          <div class="title-buttons" item-end *ngIf="!showReorderBtc">
             <button ion-button clear icon-only color="grey" (click)="goToAddView()">
               <ion-icon name="add"></ion-icon>
             </button>
@@ -198,8 +198,8 @@
               <span *ngIf="wallet.isComplete() && !wallet.needsBackup">
                 <span *ngIf="!wallet.balanceHidden && !wallet.scanning">
                   {{wallet.status && wallet.status.totalBalanceStr ? (wallet.status.totalBalanceStr) : ( wallet.cachedBalance ? wallet.cachedBalance
-                  + (wallet.cachedBalanceUpdatedOn ? ' &middot; ' + ( wallet.cachedBalanceUpdatedOn * 1000 | amTimeAgo) : '') 
-                  : '')}}
+                  + (wallet.cachedBalanceUpdatedOn ? ' &middot; ' + ( wallet.cachedBalanceUpdatedOn * 1000 | amTimeAgo) :
+                  '') : '')}}
                 </span>
                 <span *ngIf="wallet.scanning" translate>Scanning funds</span>
                 <span *ngIf="wallet.balanceHidden && !wallet.scanning">[
@@ -216,11 +216,11 @@
 
       <div class="card" *ngIf="walletsBch && walletsBch[0]">
         <ion-item-divider>
-          <div class="title" item-start>
+          <div class="title wallets-list-title" item-start>
             <img src="assets/img/bitcoin-cash-logo.svg" alt="Bitcoin Cash Wallets" width="22" />
             <span translate>Bitcoin Cash Wallets</span>
           </div>
-          <div item-end *ngIf="!showReorderBch">
+          <div class="title-buttons" item-end *ngIf="!showReorderBch">
             <button ion-button clear icon-only color="grey" (click)="goToAddView()">
               <ion-icon name="add"></ion-icon>
             </button>
@@ -254,8 +254,8 @@
               <span *ngIf="wallet.isComplete() && !wallet.needsBackup">
                 <span *ngIf="!wallet.balanceHidden && !wallet.scanning">
                   {{wallet.status && wallet.status.totalBalanceStr ? (wallet.status.totalBalanceStr) : ( wallet.cachedBalance ? wallet.cachedBalance
-                  + (wallet.cachedBalanceUpdatedOn ? ' &middot; ' + ( wallet.cachedBalanceUpdatedOn * 1000 | amTimeAgo) : '') 
-                  : '')}}
+                  + (wallet.cachedBalanceUpdatedOn ? ' &middot; ' + ( wallet.cachedBalanceUpdatedOn * 1000 | amTimeAgo) :
+                  '') : '')}}
                 </span>
                 <span *ngIf="wallet.scanning" translate>Scanning funds</span>
                 <span *ngIf="wallet.balanceHidden && !wallet.scanning">[
@@ -288,8 +288,8 @@
               <img src="assets/img/icon-card.svg" class="icon-card" />
             </ion-icon>
             <div class="item-title">BitPay Visa&reg; Card ({{card.lastFourDigits}})</div>
-            <div class="item-subtitle">{{card.balance ? ((card.balance | number:'1.2-2') + ' ' + card.currency) : 'Add funds to get started'|translate}} {{card.updatedOn 
-              ? (' &middot; ' + (card.updatedOn * 1000 | amTimeAgo)) : ''}}</div>
+            <div class="item-subtitle">{{card.balance ? ((card.balance | number:'1.2-2') + ' ' + card.currency) : 'Add funds to get started'|translate}}
+              {{card.updatedOn ? (' &middot; ' + (card.updatedOn * 1000 | amTimeAgo)) : ''}}</div>
           </button>
         </ion-list>
       </div>

--- a/src/pages/home/home.scss
+++ b/src/pages/home/home.scss
@@ -29,11 +29,30 @@ page-home {
       margin: 10px auto;
     }
   }
+  .card,
+  ion-card {
+    .wallets-list-title {
+      display: flex;
+      align-items: center;
+      max-width: 70%;
+      > img {
+        margin-right: 7px;
+      }
+      > span {
+        line-height: 18px;
+      }
+    }
+    .title-buttons {
+      display: flex;
+      button:first-child {
+        margin-right: 5px;
+      }
+    }
+  }
   .title {
     font-weight: 500;
     > img {
-      vertical-align: sub;
-      margin-right: 5px;
+      margin-right: 7px;
     }
   }
   .error {

--- a/src/pages/settings/addressbook/addressbook.html
+++ b/src/pages/settings/addressbook/addressbook.html
@@ -29,7 +29,7 @@
     <ion-list>
       <button class="contact" ion-item *ngFor="let entry of filteredAddressbook" (click)="viewEntry(entry)">
         <gravatar [name]="entry.name" [height]="30" [width]="30" [email]="entry.email"></gravatar>
-        <div>
+        <div class="contact-info">
           <div clss="item-title">{{ entry.name }}</div>
           <div class="item-subtitle">{{ entry.address }}</div>
         </div>

--- a/src/pages/settings/addressbook/addressbook.scss
+++ b/src/pages/settings/addressbook/addressbook.scss
@@ -41,5 +41,12 @@ page-addressbook {
         margin-right: 1.5rem;
       }
     }
+    .contact-info {
+      overflow: hidden;
+      .item-title {
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
+    }
   }
 }

--- a/src/pages/settings/settings.scss
+++ b/src/pages/settings/settings.scss
@@ -1,8 +1,14 @@
 page-settings {
-  .wallet-warning {
-    ion-label {
-      white-space: inherit;
-    }
+  ion-label,
+  .item-title {
+    white-space: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    line-clamp: 2;
+    -webkit-line-clamp: 2;
+    box-orient: vertical;
+    -webkit-box-orient: vertical;
   }
   .icon-wallet,
   .icon-services {


### PR DESCRIPTION
![bitpay_-_secure_bitcoin_wallet_y___fix_settings_list_when_select_an_option_with_a_long_string_as_a_name_on_copay___trello](https://user-images.githubusercontent.com/10983458/44804855-01012b80-ab99-11e8-901a-67bb037f7b0d.jpg)
![bitpay_-_secure_bitcoin_wallet_y___fix_buttons_with_long_translations_on_copay___trello](https://user-images.githubusercontent.com/10983458/44804856-01012b80-ab99-11e8-96ac-2ea4476a2656.jpg)
![bitpay_-_secure_bitcoin_wallet_y___fix_action_buttons_of_the_wallets_list_cards__for_small_devices_on_copay___trello](https://user-images.githubusercontent.com/10983458/44804857-0199c200-ab99-11e8-8a65-f14b1812074c.jpg)
![bitpay_-_secure_bitcoin_wallet](https://user-images.githubusercontent.com/10983458/44804858-0199c200-ab99-11e8-80e2-1b1315695e0a.jpg)
