### PR TITLE
Fix: lifecycle of txp-details Page

### DIFF
--- a/src/pages/txp-details/txp-details.ts
+++ b/src/pages/txp-details/txp-details.ts
@@ -117,7 +117,7 @@ export class TxpDetailsPage {
     // this.tx.hasMultiplesOutputs = true;
   }
 
-  ionViewWillEnter() {
+  ionViewDidLoad() {
     this.displayFeeValues();
     this.initActionList();
     this.checkPaypro();
@@ -134,7 +134,9 @@ export class TxpDetailsPage {
           this.GLIDERA_LOCK_TIME;
       }
     }
+  }
 
+  ionViewWillEnter() {
     this.events.subscribe('bwsEvent', (walletId: string, type: string) => {
       _.each(
         [
@@ -222,7 +224,7 @@ export class TxpDetailsPage {
     }, 10);
   }
 
-  private checkPaypro() {
+  private checkPaypro(): void {
     if (this.tx.payProUrl) {
       this.wallet.fetchPayPro(
         {
@@ -245,7 +247,7 @@ export class TxpDetailsPage {
     }
   }
 
-  private paymentTimeControl(expirationTime) {
+  private paymentTimeControl(expirationTime): void {
     let setExpirationTime = (): void => {
       let now = Math.floor(Date.now() / 1000);
       if (now > expirationTime) {


### PR DESCRIPTION
Fix: lifecycle of txp-details Page to prevent error "Could not fetch the invoice" when the last copayer sign the txp of a payPro url