### PR TITLE
Fix: importing wallet with errors in bws url

### DIFF
--- a/src/pages/add/import-wallet/import-wallet.ts
+++ b/src/pages/add/import-wallet/import-wallet.ts
@@ -260,6 +260,12 @@ export class ImportWalletPage {
       })
       .catch(err => {
         this.logger.error('Import: could not updateRemotePreferences', err);
+        this.app
+          .getRootNavs()[0]
+          .setRoot(TabsPage)
+          .then(() => {
+            this.events.publish('OpenWallet', wallet);
+          });
       });
   }
 

--- a/src/providers/profile/profile.ts
+++ b/src/providers/profile/profile.ts
@@ -647,17 +647,17 @@ export class ProfileProvider {
               .then((msg: string) => {
                 return reject(msg);
               });
-          }
-
-          this.addAndBindWalletClient(walletClient, {
-            bwsurl: opts.bwsurl
-          })
-            .then(wallet => {
-              return resolve(wallet);
+          } else {
+            this.addAndBindWalletClient(walletClient, {
+              bwsurl: opts.bwsurl
             })
-            .catch(err => {
-              return reject(err);
-            });
+              .then(wallet => {
+                return resolve(wallet);
+              })
+              .catch(err => {
+                return reject(err);
+              });
+          }
         }
       );
     });

--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -699,7 +699,7 @@ export class WalletProvider {
                   }
 
                   requestLimit = LIMIT;
-                  getNewTxs(newTxs, skip).then(txs => {
+                  return getNewTxs(newTxs, skip).then(txs => {
                     resolve(txs);
                   });
                 })
@@ -709,13 +709,18 @@ export class WalletProvider {
                     (err.message && err.message.match(/5../))
                   ) {
                     this.logger.info('Retrying history download in 5 secs...');
-                    return reject(
-                      setTimeout(() => {
-                        return getNewTxs(newTxs, skip);
-                      }, 5000)
-                    );
+                    return setTimeout(() => {
+                      return getNewTxs(newTxs, skip)
+                        .then(txs => {
+                          resolve(txs);
+                        })
+                        .catch(err => {
+                          return reject(err);
+                        });
+                    }, 5000);
+                  } else {
+                    return reject(err);
                   }
-                  return reject(err);
                 });
             });
           };


### PR DESCRIPTION
Fixes in this PR:
- Go to recently imported wallet even if we got the error: "could not update Remote Preferences"
- Prevents repetitive errors of "Error: Uncaught (in promise)" for wallets that can not download the tx history
- Prevents get stuck on loading "importing wallet..." message, If there is an error while importing a wallet