### PR TITLE
Fix: prevent logs from repeating unnecessarily

### DIFF
--- a/src/providers/profile/profile.ts
+++ b/src/providers/profile/profile.ts
@@ -273,9 +273,6 @@ export class ProfileProvider {
 
     if (this.validationLock) {
       return setTimeout(() => {
-        this.logger.debug(
-          'ValidatingWallet Locked: Retrying in: ' + retryDelay
-        );
         return this.runValidation(wallet, delay, retryDelay);
       }, retryDelay);
     }
@@ -499,7 +496,10 @@ export class ProfileProvider {
         }
 
         let skipKeyValidation: boolean = this.shouldSkipValidation(walletId);
-        if (!skipKeyValidation) this.runValidation(wallet);
+        if (!skipKeyValidation) {
+          this.logger.debug('Trying to runValidation: ' + walletId);
+          this.runValidation(wallet);
+        }
 
         this.bindWalletClient(wallet);
 
@@ -831,7 +831,10 @@ export class ProfileProvider {
       );
 
       let skipKeyValidation = this.shouldSkipValidation(credentials.walletId);
-      if (!skipKeyValidation) this.runValidation(walletClient, 500);
+      if (!skipKeyValidation) {
+        this.logger.debug('Trying to runValidation: ' + credentials.walletId);
+        this.runValidation(walletClient, 500);
+      }
 
       this.logger.debug(
         'Binding wallet:' +

--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -641,6 +641,11 @@ export class WalletProvider {
       updateOnProgress[walletId] = [cb];
        */
 
+      this.logger.debug(
+        'Trying to download Tx history for: ' +
+          walletId +
+          '. If it fails retry in 5 secs'
+      );
       this.getSavedTxs(walletId)
         .then(txsFromLocal => {
           fixTxsUnit(txsFromLocal);
@@ -671,7 +676,12 @@ export class WalletProvider {
                   );
                   skip = skip + requestLimit;
                   this.logger.debug(
-                    'Syncing TXs. Got:' + newTxs.length + ' Skip:' + skip,
+                    'Syncing TXs for:' +
+                      walletId +
+                      '. Got:' +
+                      newTxs.length +
+                      ' Skip:' +
+                      skip,
                     ' EndingTxid:',
                     endingTxid,
                     ' Continue:',
@@ -708,7 +718,6 @@ export class WalletProvider {
                     err instanceof this.errors.CONNECTION_ERROR ||
                     (err.message && err.message.match(/5../))
                   ) {
-                    this.logger.info('Retrying history download in 5 secs...');
                     return setTimeout(() => {
                       return getNewTxs(newTxs, skip)
                         .then(txs => {
@@ -1014,7 +1023,7 @@ export class WalletProvider {
       if (isHistoryCached() && !opts.force)
         return resolve(wallet.completeHistory);
 
-      this.logger.debug('Updating Transaction History');
+      this.logger.info('Updating Transaction History');
       this.updateLocalTxHistory(wallet, opts)
         .then(txs => {
           if (opts.limitTx) {


### PR DESCRIPTION
![__repetitive_logs____info__retrying_history_download_in_5_secs_____when_the_bws_url_of_a_wallet_is_incorrect_on_copay___trello](https://user-images.githubusercontent.com/10983458/45976098-37a55700-c01c-11e8-8088-bd27978588dd.jpg)

![__repetitive_logs____info__retrying_history_download_in_5_secs_____when_the_bws_url_of_a_wallet_is_incorrect_on_copay___trello](https://user-images.githubusercontent.com/10983458/45976113-4429af80-c01c-11e8-90c3-ac05a28b919f.jpg)
