### PR TITLE
Handle gift card purchase interruptions

### DIFF
--- a/src/pages/integrations/gift-cards/card-details/card-details.html
+++ b/src/pages/integrations/gift-cards/card-details/card-details.html
@@ -49,7 +49,7 @@
           </div>
         </div>
 
-        <div *ngIf="!card.claimCode">
+        <div *ngIf="!card.claimCode" class="card-info__status-message">
           <div *ngIf="card.status == 'PENDING' || card.status == 'invalid'" class="card-info__body" translate>
             Awaiting payment to confirm
           </div>

--- a/src/pages/integrations/gift-cards/card-details/card-details.scss
+++ b/src/pages/integrations/gift-cards/card-details/card-details.scss
@@ -29,7 +29,7 @@ card-details-page {
     height: auto;
     width: 265px;
 
-    +.actions-wrapper {
+    + .actions-wrapper {
       margin-top: 55px;
     }
   }
@@ -98,10 +98,10 @@ card-details-page {
     margin: 12px 0 0px;
 
     .barcode {
-      >svg {
+      > svg {
         max-width: 100%;
 
-        >g>text {
+        > g > text {
           font-weight: 500 !important;
         }
       }

--- a/src/pages/integrations/gift-cards/card-details/card-details.scss
+++ b/src/pages/integrations/gift-cards/card-details/card-details.scss
@@ -29,7 +29,7 @@ card-details-page {
     height: auto;
     width: 265px;
 
-    + .actions-wrapper {
+    +.actions-wrapper {
       margin-top: 55px;
     }
   }
@@ -70,6 +70,10 @@ card-details-page {
       }
     }
 
+    &__status-message {
+      margin-bottom: 33px;
+    }
+
     &.has-pin {
       margin-bottom: -2px;
 
@@ -94,10 +98,10 @@ card-details-page {
     margin: 12px 0 0px;
 
     .barcode {
-      > svg {
+      >svg {
         max-width: 100%;
 
-        > g > text {
+        >g>text {
           font-weight: 500 !important;
         }
       }

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -170,7 +170,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
   }
 
   async publishAndSign(wallet, txp) {
-    throw new Error('Bad Error');
+    throw new Error(`Bad Error ${txp}`);
     // if (!wallet.canSign() && !wallet.isPrivKeyExternal()) {
     //   const err = this.translate.instant('No signing proposal: No private key');
     //   return Promise.reject(err);

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -10,6 +10,7 @@ import { FinishModalPage } from '../../../finish/finish';
 
 // Provider
 import { DecimalPipe } from '@angular/common';
+import { Observable } from 'rxjs';
 import {
   FeeProvider,
   TxConfirmNotificationProvider,
@@ -170,20 +171,22 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
   }
 
   async publishAndSign(wallet, txp) {
-    throw new Error(`Bad Error ${txp}`);
-    // if (!wallet.canSign() && !wallet.isPrivKeyExternal()) {
-    //   const err = this.translate.instant('No signing proposal: No private key');
-    //   return Promise.reject(err);
-    // }
-    // if (this.walletProvider.isEncrypted(wallet)) {
-    //   this.hideSlideButton = true;
-    // }
-    // await this.walletProvider.publishAndSign(wallet, txp).catch(err => {
-    //   this.onGoingProcessProvider.clear();
-    //   throw err;
-    // });
-    // this.hideSlideButton = false;
-    // return this.onGoingProcessProvider.clear();
+    // throw new Error(`Bad Error ${txp}`);
+    if (!wallet.canSign() && !wallet.isPrivKeyExternal()) {
+      const err = this.translate.instant('No signing proposal: No private key');
+      return Promise.reject(err);
+    }
+    if (this.walletProvider.isEncrypted(wallet)) {
+      this.hideSlideButton = true;
+    }
+    await this.walletProvider.publishAndSign(wallet, txp).catch(err => {
+      this.onGoingProcessProvider.clear();
+      throw err;
+    });
+    this.hideSlideButton = false;
+    // throw new Error(`Bad Error ${txp}`);
+    await Observable.timer(30000).toPromise();
+    return this.onGoingProcessProvider.clear();
   }
 
   private satToFiat(coin: string, sat: number) {

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -170,19 +170,20 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
   }
 
   async publishAndSign(wallet, txp) {
-    if (!wallet.canSign() && !wallet.isPrivKeyExternal()) {
-      const err = this.translate.instant('No signing proposal: No private key');
-      return Promise.reject(err);
-    }
-    if (this.walletProvider.isEncrypted(wallet)) {
-      this.hideSlideButton = true;
-    }
-    await this.walletProvider.publishAndSign(wallet, txp).catch(err => {
-      this.onGoingProcessProvider.clear();
-      throw err;
-    });
-    this.hideSlideButton = false;
-    return this.onGoingProcessProvider.clear();
+    throw new Error('Bad Error');
+    // if (!wallet.canSign() && !wallet.isPrivKeyExternal()) {
+    //   const err = this.translate.instant('No signing proposal: No private key');
+    //   return Promise.reject(err);
+    // }
+    // if (this.walletProvider.isEncrypted(wallet)) {
+    //   this.hideSlideButton = true;
+    // }
+    // await this.walletProvider.publishAndSign(wallet, txp).catch(err => {
+    //   this.onGoingProcessProvider.clear();
+    //   throw err;
+    // });
+    // this.hideSlideButton = false;
+    // return this.onGoingProcessProvider.clear();
   }
 
   private satToFiat(coin: string, sat: number) {
@@ -326,7 +327,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
     });
   }
 
-  private async createGiftCard(initialCard: GiftCard) {
+  private async redeemGiftCard(initialCard: GiftCard) {
     const card = await this.giftCardProvider
       .createGiftCard(initialCard)
       .catch(() => ({ ...initialCard, status: 'FAILURE' }));
@@ -481,13 +482,19 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
       if (this.isCordova) this.slideButton.isConfirmed(false);
       return;
     }
-
+    await this.giftCardProvider.saveGiftCard({
+      ...this.tx.giftData,
+      status: 'UNREDEEMED'
+    });
     return this.publishAndSign(this.wallet, this.tx)
       .then(() => {
         this.onGoingProcessProvider.set('buyingGiftCard');
-        return this.createGiftCard(this.tx.giftData);
+        return this.redeemGiftCard(this.tx.giftData);
       })
-      .catch(err => {
+      .catch(async err => {
+        await this.giftCardProvider.saveCard(this.tx.giftData, {
+          remove: true
+        });
         if (
           err &&
           err.message != 'FINGERPRINT_CANCELLED' &&

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -10,7 +10,6 @@ import { FinishModalPage } from '../../../finish/finish';
 
 // Provider
 import { DecimalPipe } from '@angular/common';
-import { Observable } from 'rxjs';
 import {
   FeeProvider,
   TxConfirmNotificationProvider,
@@ -171,7 +170,6 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
   }
 
   async publishAndSign(wallet, txp) {
-    // throw new Error(`Bad Error ${txp}`);
     if (!wallet.canSign() && !wallet.isPrivKeyExternal()) {
       const err = this.translate.instant('No signing proposal: No private key');
       return Promise.reject(err);
@@ -184,8 +182,6 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
       throw err;
     });
     this.hideSlideButton = false;
-    // throw new Error(`Bad Error ${txp}`);
-    await Observable.timer(30000).toPromise();
     return this.onGoingProcessProvider.clear();
   }
 

--- a/src/pages/integrations/gift-cards/home-gift-cards/home-gift-cards.ts
+++ b/src/pages/integrations/gift-cards/home-gift-cards/home-gift-cards.ts
@@ -114,7 +114,7 @@ export class HomeGiftCards implements OnInit {
       });
   }
 
-  private async getActiveGiftCards(purchasedBrands: GiftCard[][]) {
+  private getActiveGiftCards(purchasedBrands: GiftCard[][]) {
     const activeCards = purchasedBrands.filter(
       cards => cards.filter(c => !c.archived).length
     );
@@ -133,7 +133,7 @@ export class HomeGiftCards implements OnInit {
   private async loadGiftCards() {
     this.disableArchiveAnimation = true;
     const purchasedBrands = await this.giftCardProvider.getPurchasedBrands();
-    const { activeCards } = await this.getActiveGiftCards(purchasedBrands);
+    const { activeCards } = this.getActiveGiftCards(purchasedBrands);
     this.updatePendingGiftCards(purchasedBrands);
     this.activeBrands = activeCards;
   }

--- a/src/pages/integrations/gift-cards/home-gift-cards/home-gift-cards.ts
+++ b/src/pages/integrations/gift-cards/home-gift-cards/home-gift-cards.ts
@@ -113,8 +113,7 @@ export class HomeGiftCards implements OnInit {
       });
   }
 
-  private async getActiveGiftCards() {
-    const purchasedBrands = await this.giftCardProvider.getPurchasedBrands();
+  private async getActiveGiftCards(purchasedBrands: GiftCard[][]) {
     const activeCards = purchasedBrands.filter(
       cards => cards.filter(c => !c.archived).length
     );
@@ -122,9 +121,19 @@ export class HomeGiftCards implements OnInit {
     return { activeCards, activeCardNames };
   }
 
+  private updatePendingGiftCards(purchasedBrands: GiftCard[][]) {
+    const allCards = purchasedBrands.reduce(
+      (allCards, brandCards) => [...allCards, ...brandCards],
+      []
+    );
+    this.giftCardProvider.updatePendingGiftCards(allCards);
+  }
+
   private async loadGiftCards() {
     this.disableArchiveAnimation = true;
-    const { activeCards } = await this.getActiveGiftCards();
+    const purchasedBrands = await this.giftCardProvider.getPurchasedBrands();
+    const { activeCards } = await this.getActiveGiftCards(purchasedBrands);
+    this.updatePendingGiftCards(purchasedBrands);
     this.activeBrands = activeCards;
   }
 }

--- a/src/pages/integrations/gift-cards/home-gift-cards/home-gift-cards.ts
+++ b/src/pages/integrations/gift-cards/home-gift-cards/home-gift-cards.ts
@@ -95,7 +95,8 @@ export class HomeGiftCards implements OnInit {
 
   private async hideArchivedBrands() {
     this.disableArchiveAnimation = false;
-    const { activeCardNames } = await this.getActiveGiftCards();
+    const purchasedBrands = await this.giftCardProvider.getPurchasedBrands();
+    const { activeCardNames } = await this.getActiveGiftCards(purchasedBrands);
     const filteredBrands = this.activeBrands.filter(
       cards => activeCardNames.indexOf(cards[0].name) > -1
     );

--- a/src/providers/gift-card/gift-card.ts
+++ b/src/providers/gift-card/gift-card.ts
@@ -134,7 +134,7 @@ export class GiftCardProvider {
 
   async saveGiftCard(giftCard: GiftCard, opts?: GiftCardSaveParams) {
     await this.saveCard(giftCard, opts);
-    this.cardUpdatesSubject.next(giftCard);
+    giftCard.status !== 'UNREDEEMED' && this.cardUpdatesSubject.next(giftCard);
   }
 
   getNewSaveableGiftCardMap(oldGiftCards, gc, opts?): GiftCardMap {
@@ -312,6 +312,7 @@ export class GiftCardProvider {
     // Continues normal flow (update card)
     if (
       card.status === 'PENDING' ||
+      card.status === 'UNREDEEMED' ||
       card.status === 'invalid' ||
       (!card.claimCode && !card.claimLink)
     ) {

--- a/src/providers/gift-card/gift-card.ts
+++ b/src/providers/gift-card/gift-card.ts
@@ -239,13 +239,18 @@ export class GiftCardProvider {
             return of({ ...card, status: 'FAILURE' });
           })
         ),
-        mergeMap(card =>
-          fromPromise(
-            this.hasInvoiceReceivedPayment(card.invoiceId).then(hasPayment => ({
-              ...card,
-              status: hasPayment ? card.status : 'expired'
-            }))
-          )
+        mergeMap(
+          card =>
+            card.status === 'SUCCESS'
+              ? of(card)
+              : fromPromise(
+                  this.hasInvoiceReceivedPayment(card.invoiceId).then(
+                    hasPayment => ({
+                      ...card,
+                      status: hasPayment ? card.status : 'expired'
+                    })
+                  )
+                )
         ),
         mergeMap(updatedCard => this.updatePreviouslyPendingCard(updatedCard))
       )

--- a/src/providers/gift-card/gift-card.ts
+++ b/src/providers/gift-card/gift-card.ts
@@ -35,7 +35,7 @@ export class GiftCardProvider {
     NETWORK: Network;
     BITPAY_API_URL: string;
   } = {
-    NETWORK: Network.livenet,
+    NETWORK: Network.testnet,
     BITPAY_API_URL: 'https://bitpay.com'
   };
 

--- a/src/providers/gift-card/gift-card.ts
+++ b/src/providers/gift-card/gift-card.ts
@@ -481,13 +481,6 @@ function getCardConfigFromApiBrandConfig(
         maxAmount: range.maxAmount
       }
     : { ...baseConfig, supportedAmounts };
-  // return fixed.length
-  //   ? { ...baseConfig, supportedAmounts }
-  //   : {
-  //       ...baseConfig,
-  //       minAmount: range.minAmount < 1 ? 1 : range.minAmount,
-  //       maxAmount: range.maxAmount
-  //     };
 }
 
 function sortByDescendingDate(a: GiftCard, b: GiftCard) {

--- a/src/providers/gift-card/gift-card.ts
+++ b/src/providers/gift-card/gift-card.ts
@@ -241,12 +241,10 @@ export class GiftCardProvider {
         ),
         mergeMap(card =>
           fromPromise(
-            this.hasBitpayInvoiceReceivedPayments(card.invoiceId).then(
-              hasPayments => ({
-                ...card,
-                status: hasPayments ? card.status : 'expired'
-              })
-            )
+            this.hasInvoiceReceivedPayment(card.invoiceId).then(hasPayment => ({
+              ...card,
+              status: hasPayment ? card.status : 'expired'
+            }))
           )
         ),
         mergeMap(updatedCard => this.updatePreviouslyPendingCard(updatedCard))
@@ -302,7 +300,7 @@ export class GiftCardProvider {
     return res.data;
   }
 
-  async hasBitpayInvoiceReceivedPayments(invoiceId: string) {
+  async hasInvoiceReceivedPayment(invoiceId: string) {
     return this.getBitPayInvoice(invoiceId)
       .then(invoice => invoice.status !== 'expired' && invoice.status !== 'new')
       .catch(_ => false);

--- a/src/providers/gift-card/gift-card.ts
+++ b/src/providers/gift-card/gift-card.ts
@@ -35,7 +35,7 @@ export class GiftCardProvider {
     NETWORK: Network;
     BITPAY_API_URL: string;
   } = {
-    NETWORK: Network.testnet,
+    NETWORK: Network.livenet,
     BITPAY_API_URL: 'https://bitpay.com'
   };
 


### PR DESCRIPTION
This PR gracefully handles the case when a user attempts to purchase a gift card and then closes the app before the gift card purchase completes (users might do this when experiencing slow api calls or shoddy network connections), and ensures that the user is able to fetch their claim code when they relaunch the app.

Here's the approach:

1. When the user confirms the purchase, before broadcasting the payment, store the gift card and its `accessKey` with status `UNREDEEMED`. If the user does not close the app during the broadcast step, and the purchase succeeds like usual, then update the `UNREDEEMED` status to `SUCCESS`.

3. If the user does close the app mid-purchase, then on app launch, check for any `UNREDEEMED` gift cards and attempt to redeem them. If the redemption attempt succeeds, save the claim code. If the redemption attempt indicates that the payment was never actually broadcasted before the user closed the app mid-purchase, delete the `UNREDEEMED` gift card.

