### PR TITLE
Fix: pin modal to prevent malfunction of the lock method

### DIFF
--- a/src/pages/pin/pin-modal/pin-modal.ts
+++ b/src/pages/pin/pin-modal/pin-modal.ts
@@ -200,7 +200,7 @@ export class PinModalPage {
 
   private isComplete(): boolean {
     if (this.currentPin.length < 4) return false;
-    this.disableButtons = true;
+    if (this.action != 'pinSetUp') this.disableButtons = true;
     return true;
   }
 

--- a/src/pages/pin/pin-modal/pin-modal.ts
+++ b/src/pages/pin/pin-modal/pin-modal.ts
@@ -62,7 +62,7 @@ export class PinModalPage {
     this.expires = '';
     this.incorrect = false;
 
-    this.unregister = this.platform.registerBackButtonAction(() => { });
+    this.unregister = this.platform.registerBackButtonAction(() => {});
 
     this.action = this.navParams.get('action');
 
@@ -103,7 +103,6 @@ export class PinModalPage {
 
   private checkIfLocked(): void {
     this.persistenceProvider.getLockStatus().then((isLocked: string) => {
-
       if (!isLocked) {
         this.disableButtons = null;
         return;
@@ -168,7 +167,7 @@ export class PinModalPage {
       this.showLockTimer();
       this.setLockRelease();
     } else {
-      this.disableButtons = null
+      this.disableButtons = null;
     }
   }
 


### PR DESCRIPTION
This PR:
- Avoids to block the app when stay open in the background without having failed 3 times in the unlock code.

- Avoids to get garbage characters, and  place multiple errors in the code entry unintentionally when type more than 4 numbers