### PR TITLE
Add ionic-image-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13803,6 +13803,11 @@
       "resolved": "https://registry.npmjs.org/ionic-angular/-/ionic-angular-3.9.2.tgz",
       "integrity": "sha512-BEZ6magY1i5GwM9ki/MOpszUz62+g518HsGICtw9TE1D4v9Eb6n/o7e+X0vtvpK4TdouFjQ8r5XA9VPAKW9/+Q=="
     },
+    "ionic-image-loader": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/ionic-image-loader/-/ionic-image-loader-6.3.2.tgz",
+      "integrity": "sha512-g29elABmx7deFewd3WCsxNjaT76oC92keFdKfXW1YnzDiXDeZRqRKHhAlLZf3g8kcYQpArJaIggnzYV/tjr3lA=="
+    },
     "ionic-mocks": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ionic-mocks/-/ionic-mocks-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "es6-promise-plugin": "4.2.2",
     "gettext-parser": "1.3.0",
     "ionic-angular": "3.9.2",
+    "ionic-image-loader": "6.3.2",
     "ionicons": "3.0.0",
     "lodash": "4.17.11",
     "ngx-barcode": "0.2.4",


### PR DESCRIPTION
Adds https://github.com/zyra/ionic-image-loader

This package will boost the loading speed of gift card images (or any images initially fetched remotely) by storing them locally on the device after the initial fetch. This package also ensures that users are able to properly view (and redeem) previously purchased gift cards even when experiencing poor or nonexistent network connectivity.