### PR TITLE
Remote gift card catalog fixes

### DIFF
--- a/src/pages/wallet-details/wallet-details.html
+++ b/src/pages/wallet-details/wallet-details.html
@@ -185,7 +185,7 @@
                       width="40">
                     <ng-container *ngIf="supportedCards | async as cardConfig">
                       <img-loader class="icon-services" *ngIf="tx.customData.service === 'giftcards'" [src]="cardConfig[tx.customData.giftCardName]?.icon"
-                        width="40"></img-loader>
+                        width="40" fallbackUrl="assets/img/gift-cards/gift-cards-icon.svg"></img-loader>
                     </ng-container>
                     <img class="icon-services" src="assets/img/bitpay-card/icon-bitpay.svg" *ngIf="tx.customData.service == 'debitcard'"
                       width="40">

--- a/src/providers/gift-card/gift-card.ts
+++ b/src/providers/gift-card/gift-card.ts
@@ -372,9 +372,9 @@ export class GiftCardProvider {
     ]);
     const cachedCardNames = Object.keys(cachedApiCardConfig);
     const availableCardNames = availableCards.map(c => c.name);
-    const uniqueCardNames = [
-      ...new Set([...availableCardNames, ...cachedCardNames])
-    ];
+    const uniqueCardNames = Array.from(
+      new Set([...availableCardNames, ...cachedCardNames])
+    );
     const supportedCards = uniqueCardNames
       .map(cardName => {
         const freshConfig = availableCards.find(c => c.name === cardName);


### PR DESCRIPTION
1. Fixes TS error related to using spread operator on `Set`.
2. Adds a generic gift card fallback image that will be displayed in wallet transaction history if the brand specific icon cannot be fetched for any reason.