### PR TITLE
Add base64-js to the dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3132,9 +3132,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "base64id": {
       "version": "1.0.0",
@@ -9531,6 +9531,11 @@
         "xcode": "^1.0.0"
       },
       "dependencies": {
+        "base64-js": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+        },
         "plist": {
           "version": "github:cmgustavo/plist.js#a8dddea180a8388102740feca9b9cd97c9da8539",
           "from": "github:cmgustavo/plist.js",

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "@zxing/library": "0.8.2",
     "@zxing/ngx-scanner": "1.2.1",
     "angular2-moment": "1.7.1",
+    "base64-js": "^1.3.0",
     "bitauth": "git+https://github.com/bitpay/bitauth.git#copay",
     "bitcore-wallet-client": "6.8.1",
     "buffer-compare": "1.1.1",


### PR DESCRIPTION
On a fresh install, I had to also install `base64-js` to get copay to run