### PR TITLE
Gift Card Improvements

### DIFF
--- a/src/components/amount-picker/amount-picker.html
+++ b/src/components/amount-picker/amount-picker.html
@@ -12,7 +12,7 @@
     <img src="assets/img/icon-plus.svg">
   </div>
 </div>
-<div class="amount-picker__values" *ngIf="supportedAmounts">
+<div class="amount-picker__values" *ngIf="supportedAmounts && supportedAmounts.length > 1">
   <div>Purchase Amounts:</div>
   <div><span *ngFor="let amount of supportedAmounts; let last = last">{{amount | formatCurrency:currency:'minimal'}}<span
         *ngIf="!last">,</span>

--- a/src/pages/integrations/gift-cards/card-details/card-details.html
+++ b/src/pages/integrations/gift-cards/card-details/card-details.html
@@ -53,7 +53,8 @@
         </div>
 
         <div *ngIf="!card.claimCode" class="card-info__status-message">
-          <div *ngIf="card.status === 'PENDING' || card.status === 'invalid'" class="card-info__body" translate>
+          <div *ngIf="card.status === 'PENDING' || card.status === 'invalid' || card.status === 'expired'" class="card-info__body"
+            translate>
             Awaiting payment to confirm
           </div>
           <div *ngIf="card.status == 'FAILURE' || card.status == 'RESEND'" class="card-info__body" translate>

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.html
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.html
@@ -12,7 +12,7 @@
     <ion-item class="confirm-header">
       <div class="confirm-header__amount">
         <div class="gift-card-title">
-          {{cardConfig?.name}} Gift Card
+          {{cardConfig?.displayName}} Gift Card
         </div>
         <div class="amount-label">
           <div class="amount">{{amount | formatCurrency:currency}}</div>

--- a/src/providers/persistence/persistence.ts
+++ b/src/providers/persistence/persistence.ts
@@ -39,7 +39,10 @@ const Keys = {
   CONFIG: 'config',
   FEEDBACK: 'feedback',
   FOCUSED_WALLET_ID: 'focusedWalletId',
-  GIFT_CARD_CONFIG_CACHE: 'giftCardConfigCache',
+  GIFT_CARD_CONFIG_CACHE: (network: Network) => {
+    const suffix = network === Network.livenet ? '' : `-${network}`;
+    return `giftCardConfigCache${suffix}`;
+  },
   ACTIVE_GIFT_CARDS: (network: Network) => {
     return `activeGiftCards-${network}`;
   },
@@ -341,10 +344,6 @@ export class PersistenceProvider {
     this.removeWalletOrder(walletId);
   }
 
-  setGiftCardConfigCache(data) {
-    return this.storage.set(Keys.GIFT_CARD_CONFIG_CACHE, data);
-  }
-
   getActiveGiftCards(network: Network) {
     return this.storage.get(Keys.ACTIVE_GIFT_CARDS(network));
   }
@@ -353,12 +352,16 @@ export class PersistenceProvider {
     return this.storage.set(Keys.ACTIVE_GIFT_CARDS(network), data);
   }
 
-  getGiftCardConfigCache() {
-    return this.storage.get(Keys.GIFT_CARD_CONFIG_CACHE);
+  getGiftCardConfigCache(network: Network) {
+    return this.storage.get(Keys.GIFT_CARD_CONFIG_CACHE(network));
   }
 
-  removeGiftCardConfigCache() {
-    return this.storage.remove(Keys.GIFT_CARD_CONFIG_CACHE);
+  removeGiftCardConfigCache(network: Network) {
+    return this.storage.remove(Keys.GIFT_CARD_CONFIG_CACHE(network));
+  }
+
+  setGiftCardConfigCache(network: Network, data) {
+    return this.storage.set(Keys.GIFT_CARD_CONFIG_CACHE(network), data);
   }
 
   setGiftCardUserInfo(data) {


### PR DESCRIPTION
1. Ensures only confirmed inputs can be used for gift card purchases to prevent payment issues
2. Skips the 2nd confirm step (the confirmation alert) for gift card purchases for a faster checkout experience 
3. Splits `cardConfigCache` into testnet and livenet storage keys to prevent overriding the production cache during development
4. Hides the `Purchase Amounts: ` list if only one purchase amount is available
5. Uses the gift card `displayName` as the title on the confirm page