### PR TITLE
[FEAT] UI improvements for backup game

### DIFF
--- a/src/pages/backup/backup-game/backup-game.html
+++ b/src/pages/backup/backup-game/backup-game.html
@@ -8,7 +8,7 @@
 <ion-content no-bounce>
   <div class="key-container" [hidden]="mnemonicHasPassphrase && selectComplete">
     <div class="word-container">
-      <ion-slides #gameSlides class="word-slides">
+      <ion-slides #gameSlides class="word-slides" slidesPerView="2" spaceBetween="20" centeredSlides="true">
         <ion-slide *ngFor="let mnemonicWord of mnemonicWords; let i = index">
           <div class="word">
             <span *ngIf="customWords && customWords[i]">{{customWords[i].word}}</span>

--- a/src/pages/backup/backup-game/backup-game.scss
+++ b/src/pages/backup/backup-game/backup-game.scss
@@ -1,4 +1,7 @@
 page-backup-game {
+  ion-content.content {
+    background: white;
+  }
   .key-container {
     height: 95%;
     text-align: center;
@@ -11,13 +14,17 @@ page-backup-game {
       text-align: center;
       .word-slides {
         .word {
-          background: color($colors, light);
+          background-color: #f6f7fc;
           margin: auto;
           border-radius: 3px;
           color: color($colors, secondary);
           text-align: center;
-          max-width: 260px;
-          min-height: 11rem;
+          min-width: 190px;
+          min-height: 171px;
+          @media (max-width: 400px) {
+            min-width: 160px;
+            min-height: 130px;
+          }
           display: flex;
           justify-content: center;
           align-items: center;
@@ -36,12 +43,12 @@ page-backup-game {
             border-bottom: 1px color($colors, primary) dashed;
             width: 80%;
             position: absolute;
-            bottom: 1.5rem;
+            bottom: 3.5rem;
           }
         }
         .word-number {
           margin-top: 1rem;
-          font-weight: 500;
+          font-weight: bold;
         }
       }
     }
@@ -69,6 +76,9 @@ page-backup-game {
       margin: 0 auto;
       padding: 0.8rem;
       .button {
+        box-shadow: none;
+        background-color: #f6f6f6;
+        color: color($colors, dark);
         height: 3rem;
         font-size: 14px;
         margin: 5px;

--- a/src/pages/backup/backup-key/backup-key.scss
+++ b/src/pages/backup/backup-key/backup-key.scss
@@ -1,4 +1,7 @@
 page-backup-key {
+  ion-content.content {
+    background: white;
+  }
   .key-container {
     height: 85%;
     display: flex;
@@ -10,9 +13,9 @@ page-backup-key {
     .word-container {
       text-align: center;
       .word-title {
-        font-size: 14px;
+        font-size: 18px;
         padding: 20px;
-        color: color($colors, grey);
+        color: color($colors, dark);
       }
       .word {
         background: color($colors, light);
@@ -21,8 +24,7 @@ page-backup-key {
         color: #192c3a;
         text-align: center;
         min-width: 220px;
-        max-width: 500px;
-        min-height: 11rem;
+        min-height: 171px;
         display: flex;
         justify-content: center;
         align-items: center;
@@ -41,7 +43,7 @@ page-backup-key {
       }
       .word-number {
         margin-top: 1rem;
-        font-weight: 500;
+        font-weight: bold;
       }
     }
   }


### PR DESCRIPTION
Tappable words are now in grey container with no shadow hex color #F6F6F6
Large words are in a blue background container hex color #F6F7FC
Increase the height and width of large words container.
Page background to white.
Make words more of a carousel showing the edge of the previous and next card up.

Old:
![BitPay](https://user-images.githubusercontent.com/10999037/54771891-fe256100-4be4-11e9-889c-53f765b16801.png)

New
![BitPay](https://user-images.githubusercontent.com/10999037/54771669-85260980-4be4-11e9-9d13-35d07a7adddc.png)
