### PR TITLE
fix(iOS): show virtual keyboard without padding and move buttons to top-right

### DIFF
--- a/app-template/config-template.xml
+++ b/app-template/config-template.xml
@@ -27,6 +27,7 @@
     <preference name="KeyboardResize" value="true" />
     <preference name="HideKeyboardFormAccessoryBar" value="false"/>
     <preference name="KeyboardResizeMode" value="ionic" />
+    <preference name="KeyboardDisplayRequiresUserAction" value="false" />
 
     <preference name="BackupWebStorage" value="none"/>
     <preference name="Orientation" value="default" />
@@ -88,9 +89,6 @@
       <variable name="THIRD_URL_SCHEME" value="bitcoincash" />
     </plugin>
     <plugin name="cordova-plugin-fcm" spec="https://github.com/cmgustavo/cordova-plugin-fcm.git#v4.1" />
-
-    <!-- Keyboard input focus fix -->
-    <plugin name="cordova-plugin-wkwebview-inputfocusfix" spec="https://github.com/cmgustavo/cordova-plugin-wkwebview-inputfocusfix.git#3a4e7908331ae110d6fc269c6c6f11b5e756e3f7" />
 
     <plugin name="cordova-plugin-wkwebview-engine" spec="1.1.4" />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11993,10 +11993,6 @@
       "resolved": "https://registry.npmjs.org/cordova-plugin-wkwebview-engine/-/cordova-plugin-wkwebview-engine-1.1.4.tgz",
       "integrity": "sha1-EbnPoRTsBSXFxj5nok6rQVcDQGA="
     },
-    "cordova-plugin-wkwebview-inputfocusfix": {
-      "version": "git+https://github.com/cmgustavo/cordova-plugin-wkwebview-inputfocusfix.git#3a4e7908331ae110d6fc269c6c6f11b5e756e3f7",
-      "from": "git+https://github.com/cmgustavo/cordova-plugin-wkwebview-inputfocusfix.git#3a4e7908331ae110d6fc269c6c6f11b5e756e3f7"
-    },
     "cordova-plugin-x-socialsharing": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/cordova-plugin-x-socialsharing/-/cordova-plugin-x-socialsharing-5.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -219,7 +219,6 @@
     "cordova-plugin-vibration": "3.1.0",
     "cordova-plugin-whitelist": "1.3.3",
     "cordova-plugin-wkwebview-engine": "1.1.4",
-    "cordova-plugin-wkwebview-inputfocusfix": "https://github.com/cmgustavo/cordova-plugin-wkwebview-inputfocusfix.git#3a4e7908331ae110d6fc269c6c6f11b5e756e3f7",
     "cordova-plugin-x-socialsharing": "5.3.2",
     "cordova-plugin-x-toast": "2.6.0",
     "es6-promise-plugin": "4.2.2",
@@ -328,8 +327,7 @@
       "cordova-plugin-vibration": {},
       "im.ltdev.cordova.UserAgent": {},
       "cordova-launch-review": {},
-      "cordova-plugin-wkwebview-engine": {},
-      "cordova-plugin-wkwebview-inputfocusfix": {}
+      "cordova-plugin-wkwebview-engine": {}
     },
     "platforms": [
       "android",

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -58,7 +58,7 @@ ion-label {
 }
 
 .button-footer {
-  margin: 0px;
+  margin: 0;
   height: 70px;
   width: 100%;
   font-size: 18px;

--- a/src/pages/add/create-wallet/create-wallet.html
+++ b/src/pages/add/create-wallet/create-wallet.html
@@ -1,5 +1,9 @@
-<wide-header-page title="{{'Wallet Configuration' | translate}}">
-  <div page-content>
+<ion-header>
+  <ion-navbar>
+    <ion-title>{{'Wallet Configuration' | translate}}</ion-title>
+  </ion-navbar>
+</ion-header>
+<ion-content no-bounce>
     <form [formGroup]="createForm">
       <ion-item>
         <ion-label floating>{{'Wallet name' | translate}}</ion-label>
@@ -93,12 +97,11 @@
         </label-tip>
       </div>
     </form>
-  </div>
-  <div footer-content>
-    <ion-toolbar>
-      <button ion-button full class="button-footer" (click)="setOptsAndCreate()" [disabled]="!createForm.valid">
-        {{createLabel}}
-      </button>
-    </ion-toolbar>
-  </div>
-</wide-header-page>
+</ion-content>
+<ion-footer *ngIf="!hideConfirm">
+  <ion-toolbar>
+    <button ion-button full class="button-footer" (click)="setOptsAndCreate()" [disabled]="!createForm.valid">
+      {{createLabel}}
+    </button>
+  </ion-toolbar>
+</ion-footer>

--- a/src/pages/add/create-wallet/create-wallet.html
+++ b/src/pages/add/create-wallet/create-wallet.html
@@ -1,6 +1,11 @@
 <ion-header>
   <ion-navbar>
-    <ion-title>{{'Wallet Configuration' | translate}}</ion-title>
+    <ion-title>{{ createLabel }}</ion-title>
+    <ion-buttons end>
+      <button ion-button (click)="setOptsAndCreate()" [disabled]="!createForm.valid">
+        <span translate>Create</span>
+      </button>
+    </ion-buttons>
   </ion-navbar>
 </ion-header>
 <ion-content no-bounce>
@@ -49,7 +54,7 @@
         <span *ngIf="showAdvOpts">{{'Hide advanced options' | translate}}</span>
       </button>
 
-      <div *ngIf="showAdvOpts">
+      <div *ngIf="showAdvOpts" padding-bottom>
         <ion-item>
           <ion-label stacked>Wallet Service URL</ion-label>
           <ion-input type="text" formControlName="bwsURL"></ion-input>
@@ -98,10 +103,3 @@
       </div>
     </form>
 </ion-content>
-<ion-footer *ngIf="!hideConfirm">
-  <ion-toolbar>
-    <button ion-button full class="button-footer" (click)="setOptsAndCreate()" [disabled]="!createForm.valid">
-      {{createLabel}}
-    </button>
-  </ion-toolbar>
-</ion-footer>

--- a/src/pages/add/create-wallet/create-wallet.ts
+++ b/src/pages/add/create-wallet/create-wallet.ts
@@ -10,6 +10,7 @@ import { ConfigProvider } from '../../../providers/config/config';
 import { DerivationPathHelperProvider } from '../../../providers/derivation-path-helper/derivation-path-helper';
 import { ExternalLinkProvider } from '../../../providers/external-link/external-link';
 import { OnGoingProcessProvider } from '../../../providers/on-going-process/on-going-process';
+import { PlatformProvider } from '../../../providers/platform/platform';
 import { PopupProvider } from '../../../providers/popup/popup';
 import { ProfileProvider } from '../../../providers/profile/profile';
 import { PushNotificationsProvider } from '../../../providers/push-notifications/push-notifications';
@@ -56,6 +57,7 @@ export class CreateWalletPage implements OnInit {
   public cancelText: string;
   public createForm: FormGroup;
   public createLabel: string;
+  public hideConfirm: boolean;
 
   constructor(
     private navCtrl: NavController,
@@ -72,7 +74,8 @@ export class CreateWalletPage implements OnInit {
     private events: Events,
     private pushNotificationsProvider: PushNotificationsProvider,
     private externalLinkProvider: ExternalLinkProvider,
-    private bwcErrorProvider: BwcErrorProvider
+    private bwcErrorProvider: BwcErrorProvider,
+    private platformProvider: PlatformProvider
   ) {
     this.okText = this.translate.instant('Ok');
     this.cancelText = this.translate.instant('Cancel');
@@ -111,6 +114,18 @@ export class CreateWalletPage implements OnInit {
   ngOnInit() {
     if (this.isShared) {
       this.createForm.get('myName').setValidators([Validators.required]);
+    }
+  }
+
+  ionViewWillEnter() {
+    if (this.platformProvider.isCordova) {
+      window.addEventListener('keyboardWillShow', () => {
+        this.hideConfirm = true;
+      });
+
+      window.addEventListener('keyboardWillHide', () => {
+        this.hideConfirm = false;
+      });
     }
   }
 

--- a/src/pages/add/create-wallet/create-wallet.ts
+++ b/src/pages/add/create-wallet/create-wallet.ts
@@ -10,7 +10,6 @@ import { ConfigProvider } from '../../../providers/config/config';
 import { DerivationPathHelperProvider } from '../../../providers/derivation-path-helper/derivation-path-helper';
 import { ExternalLinkProvider } from '../../../providers/external-link/external-link';
 import { OnGoingProcessProvider } from '../../../providers/on-going-process/on-going-process';
-import { PlatformProvider } from '../../../providers/platform/platform';
 import { PopupProvider } from '../../../providers/popup/popup';
 import { ProfileProvider } from '../../../providers/profile/profile';
 import { PushNotificationsProvider } from '../../../providers/push-notifications/push-notifications';
@@ -57,7 +56,6 @@ export class CreateWalletPage implements OnInit {
   public cancelText: string;
   public createForm: FormGroup;
   public createLabel: string;
-  public hideConfirm: boolean;
 
   constructor(
     private navCtrl: NavController,
@@ -74,8 +72,7 @@ export class CreateWalletPage implements OnInit {
     private events: Events,
     private pushNotificationsProvider: PushNotificationsProvider,
     private externalLinkProvider: ExternalLinkProvider,
-    private bwcErrorProvider: BwcErrorProvider,
-    private platformProvider: PlatformProvider
+    private bwcErrorProvider: BwcErrorProvider
   ) {
     this.okText = this.translate.instant('Ok');
     this.cancelText = this.translate.instant('Cancel');
@@ -104,8 +101,8 @@ export class CreateWalletPage implements OnInit {
     this.createForm.controls['coin'].setValue(this.coin);
     this.createLabel =
       this.coin === 'btc'
-        ? this.translate.instant('Create BTC Wallet')
-        : this.translate.instant('Create BCH Wallet');
+        ? this.translate.instant('BTC Wallet')
+        : this.translate.instant('BCH Wallet');
 
     this.setTotalCopayers(this.tc);
     this.updateRCSelect(this.tc);
@@ -114,18 +111,6 @@ export class CreateWalletPage implements OnInit {
   ngOnInit() {
     if (this.isShared) {
       this.createForm.get('myName').setValidators([Validators.required]);
-    }
-  }
-
-  ionViewWillEnter() {
-    if (this.platformProvider.isCordova) {
-      window.addEventListener('keyboardWillShow', () => {
-        this.hideConfirm = true;
-      });
-
-      window.addEventListener('keyboardWillHide', () => {
-        this.hideConfirm = false;
-      });
     }
   }
 

--- a/src/pages/add/create-wallet/create-wallet.ts
+++ b/src/pages/add/create-wallet/create-wallet.ts
@@ -244,8 +244,11 @@ export class CreateWalletPage implements OnInit {
         this.pushNotificationsProvider.updateSubscription(wallet);
         this.setBackupFlagIfNeeded(wallet.credentials.walletId);
         this.setFingerprintIfNeeded(wallet.credentials.walletId);
-        this.navCtrl.popToRoot();
-        this.events.publish('OpenWallet', wallet);
+        this.navCtrl.popToRoot().then(() => {
+          setTimeout(() => {
+            this.events.publish('OpenWallet', wallet);
+          }, 1000);
+        });
       })
       .catch(err => {
         this.onGoingProcessProvider.clear();

--- a/src/pages/add/import-wallet/import-wallet.html
+++ b/src/pages/add/import-wallet/import-wallet.html
@@ -1,6 +1,11 @@
 <ion-header>
   <ion-navbar>
-    <ion-title>{{'Import wallet' | translate}}</ion-title>
+    <ion-title>{{ createLabel }}</ion-title>
+    <ion-buttons end>
+      <button ion-button (click)="import()" [disabled]="!importForm.valid">
+        <span translate>Import</span>
+      </button>
+    </ion-buttons>
   </ion-navbar>
 </ion-header>
 
@@ -49,7 +54,7 @@
 
       <ion-item *ngIf="isSafari || isCordova">
         <ion-label floating>{{'Paste the backup plain text code' | translate}}</ion-label>
-        <ion-textarea formControlName="backupText" rows="5" [value]="importForm.value.backupText"></ion-textarea>
+        <ion-textarea formControlName="backupText" rows="7" [value]="importForm.value.backupText"></ion-textarea>
       </ion-item>
 
       <ion-item>
@@ -70,7 +75,7 @@
       </div>
     </label-tip>
  -->
-    <ion-item *ngIf="selectedTab != 'file' && !importForm.value.importVault">
+    <ion-item *ngIf="selectedTab != 'file' && !importForm.value.importVault" [hidden]="true">
       <ion-label floating>{{'Coin' | translate}}</ion-label>
       <ion-select okText="{{okText}}" cancelText="{{cancelText}}" formControlName="coin">
         <ion-option value="btc">Bitcoin (BTC)</ion-option>
@@ -86,7 +91,7 @@
       <span *ngIf="showAdvOpts">{{'Hide advanced options' | translate}}</span>
     </button>
 
-    <div *ngIf="showAdvOpts">
+    <div *ngIf="showAdvOpts" padding-bottom>
       <div *ngIf="selectedTab == 'words'">
         <ion-item *ngIf="!importForm.value.importVault" class="with-label">
           <ion-label floating>{{'Password' | translate}}</ion-label>
@@ -126,11 +131,3 @@
     </div>
   </form>
 </ion-content>
-
-<ion-footer *ngIf="!hideConfirm">
-  <ion-toolbar>
-    <button ion-button full class="button-footer" (click)="import()" [disabled]="!importForm.valid">
-      {{'Import wallet' | translate}}
-    </button>
-  </ion-toolbar>
-</ion-footer>

--- a/src/pages/add/import-wallet/import-wallet.html
+++ b/src/pages/add/import-wallet/import-wallet.html
@@ -127,7 +127,7 @@
   </form>
 </ion-content>
 
-<ion-footer>
+<ion-footer *ngIf="!hideConfirm">
   <ion-toolbar>
     <button ion-button full class="button-footer" (click)="import()" [disabled]="!importForm.valid">
       {{'Import wallet' | translate}}

--- a/src/pages/add/import-wallet/import-wallet.scss
+++ b/src/pages/add/import-wallet/import-wallet.scss
@@ -1,4 +1,7 @@
 page-import-wallet {
+  textarea {
+    height: 10vh;
+  }
   .assertive {
     color: color($colors, danger);
     ion-label {

--- a/src/pages/add/import-wallet/import-wallet.ts
+++ b/src/pages/add/import-wallet/import-wallet.ts
@@ -1,12 +1,11 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
-import { App, Events, NavController, NavParams } from 'ionic-angular';
+import { Events, NavController, NavParams } from 'ionic-angular';
 import { Logger } from '../../../providers/logger/logger';
 
 // Pages
 import { ScanPage } from '../../scan/scan';
-import { TabsPage } from '../../tabs/tabs';
 
 // Providers
 import { ActionSheetProvider } from '../../../providers/action-sheet/action-sheet';
@@ -52,7 +51,6 @@ export class ImportWalletPage {
   public createLabel: string;
 
   constructor(
-    private app: App,
     private navCtrl: NavController,
     private navParams: NavParams,
     private form: FormBuilder,
@@ -268,19 +266,7 @@ export class ImportWalletPage {
       this.profileProvider.setBackupFlag(wallet.credentials.walletId);
       this.pushNotificationsProvider.updateSubscription(wallet);
     });
-
-    if (this.importForm.value.importVault) {
-      // using setRoot(TabsPage) as workaround when comming from scanner
-      this.app.getRootNavs()[0].setRoot(TabsPage);
-    } else {
-      // using setRoot(TabsPage) as workaround when comming from scanner
-      this.app
-        .getRootNavs()[0]
-        .setRoot(TabsPage)
-        .then(() => {
-          this.events.publish('OpenWallet', wallets[0]);
-        });
-    }
+    this.navCtrl.popToRoot();
   }
 
   private importExtendedPrivateKey(xPrivKey, opts) {
@@ -467,7 +453,8 @@ export class ImportWalletPage {
         const opts: Partial<WalletOptions> = {};
         opts.bwsurl = this.importForm.value.bwsURL;
         opts.coin = this.importForm.value.coin;
-        this.importBlob(this.reader.result, opts);
+        const reader: string = this.reader.result.toString();
+        this.importBlob(reader, opts);
       }
     };
   }

--- a/src/pages/add/import-wallet/import-wallet.ts
+++ b/src/pages/add/import-wallet/import-wallet.ts
@@ -49,7 +49,7 @@ export class ImportWalletPage {
   public okText: string;
   public cancelText: string;
   public coin: string;
-  public hideConfirm: boolean;
+  public createLabel: string;
 
   constructor(
     private app: App,
@@ -103,6 +103,10 @@ export class ImportWalletPage {
     });
     this.importForm.controls['coin'].setValue(this.coin);
     this.events.subscribe('Local/BackupScan', this.updateWordsHandler);
+    this.createLabel =
+      this.coin === 'btc'
+        ? this.translate.instant('BTC Wallet')
+        : this.translate.instant('BCH Wallet');
 
     this.persistenceProvider.getVault().then(vault => {
       if (vault) this.importForm.controls['importVault'].disable();
@@ -112,15 +116,6 @@ export class ImportWalletPage {
   ionViewWillEnter() {
     if (this.code) {
       this.processWalletInfo(this.code);
-    }
-    if (this.isCordova) {
-      window.addEventListener('keyboardWillShow', () => {
-        this.hideConfirm = true;
-      });
-
-      window.addEventListener('keyboardWillHide', () => {
-        this.hideConfirm = false;
-      });
     }
   }
 

--- a/src/pages/add/import-wallet/import-wallet.ts
+++ b/src/pages/add/import-wallet/import-wallet.ts
@@ -49,6 +49,7 @@ export class ImportWalletPage {
   public okText: string;
   public cancelText: string;
   public coin: string;
+  public hideConfirm: boolean;
 
   constructor(
     private app: App,
@@ -111,6 +112,15 @@ export class ImportWalletPage {
   ionViewWillEnter() {
     if (this.code) {
       this.processWalletInfo(this.code);
+    }
+    if (this.isCordova) {
+      window.addEventListener('keyboardWillShow', () => {
+        this.hideConfirm = true;
+      });
+
+      window.addEventListener('keyboardWillHide', () => {
+        this.hideConfirm = false;
+      });
     }
   }
 

--- a/src/pages/add/join-wallet/join-wallet.html
+++ b/src/pages/add/join-wallet/join-wallet.html
@@ -1,5 +1,10 @@
-<wide-header-page title="{{'Join Shared Wallet' | translate}}">
-  <div page-content>
+<ion-header>
+  <ion-navbar>
+    <ion-title>{{'Join Shared Wallet' | translate}}</ion-title>
+  </ion-navbar>
+</ion-header>
+
+<ion-content no-bounce>
     <form [formGroup]="joinForm">
       <ion-item>
         <ion-label floating>{{'Your name' | translate}}</ion-label>
@@ -44,12 +49,11 @@
         </ion-item>
       </div>
     </form>
-  </div>
-  <div footer-content>
-    <ion-toolbar>
-      <button ion-button full class="button-footer" (click)="setOptsAndJoin()" [disabled]="!joinForm.valid">
-        {{'Join wallet' | translate}}
-      </button>
-    </ion-toolbar>
-  </div>
-</wide-header-page>
+</ion-content>
+<ion-footer *ngIf="!hideConfirm">
+  <ion-toolbar>
+    <button ion-button full class="button-footer" (click)="setOptsAndJoin()" [disabled]="!joinForm.valid">
+      {{'Join wallet' | translate}}
+    </button>
+  </ion-toolbar>
+</ion-footer>

--- a/src/pages/add/join-wallet/join-wallet.html
+++ b/src/pages/add/join-wallet/join-wallet.html
@@ -1,6 +1,11 @@
 <ion-header>
   <ion-navbar>
-    <ion-title>{{'Join Shared Wallet' | translate}}</ion-title>
+    <ion-title>{{'Shared Wallet' | translate}}</ion-title>
+    <ion-buttons end>
+      <button ion-button (click)="setOptsAndJoin()" [disabled]="!joinForm.valid">
+        <span translate>Join</span>
+      </button>
+    </ion-buttons>
   </ion-navbar>
 </ion-header>
 
@@ -25,7 +30,7 @@
         <span *ngIf="showAdvOpts">{{'Hide advanced options' | translate}}</span>
       </button>
 
-      <div *ngIf="showAdvOpts">
+      <div *ngIf="showAdvOpts" padding-bottom>
         <ion-item>
           <ion-label floating>Wallet Service URL</ion-label>
           <ion-input type="text" formControlName="bwsURL"></ion-input>
@@ -50,10 +55,3 @@
       </div>
     </form>
 </ion-content>
-<ion-footer *ngIf="!hideConfirm">
-  <ion-toolbar>
-    <button ion-button full class="button-footer" (click)="setOptsAndJoin()" [disabled]="!joinForm.valid">
-      {{'Join wallet' | translate}}
-    </button>
-  </ion-toolbar>
-</ion-footer>

--- a/src/pages/add/join-wallet/join-wallet.ts
+++ b/src/pages/add/join-wallet/join-wallet.ts
@@ -15,7 +15,6 @@ import { ConfigProvider } from '../../../providers/config/config';
 import { DerivationPathHelperProvider } from '../../../providers/derivation-path-helper/derivation-path-helper';
 import { Logger } from '../../../providers/logger/logger';
 import { OnGoingProcessProvider } from '../../../providers/on-going-process/on-going-process';
-import { PlatformProvider } from '../../../providers/platform/platform';
 import { PopupProvider } from '../../../providers/popup/popup';
 import { ProfileProvider } from '../../../providers/profile/profile';
 import { PushNotificationsProvider } from '../../../providers/push-notifications/push-notifications';
@@ -36,7 +35,6 @@ export class JoinWalletPage {
   public okText: string;
   public cancelText: string;
   public joinForm: FormGroup;
-  public hideConfirm: boolean;
 
   private derivationPathByDefault: string;
   private derivationPathForTestnet: string;
@@ -60,8 +58,7 @@ export class JoinWalletPage {
     private events: Events,
     private pushNotificationsProvider: PushNotificationsProvider,
     private actionSheetProvider: ActionSheetProvider,
-    private clipboardProvider: ClipboardProvider,
-    private platformProvider: PlatformProvider
+    private clipboardProvider: ClipboardProvider
   ) {
     this.okText = this.translate.instant('Ok');
     this.cancelText = this.translate.instant('Cancel');
@@ -111,15 +108,6 @@ export class JoinWalletPage {
       let data: string = this.navParams.data.url;
       data = data.replace('copay:', '');
       this.onQrCodeScannedJoin(data);
-    }
-    if (this.platformProvider.isCordova) {
-      window.addEventListener('keyboardWillShow', () => {
-        this.hideConfirm = true;
-      });
-
-      window.addEventListener('keyboardWillHide', () => {
-        this.hideConfirm = false;
-      });
     }
   }
 

--- a/src/pages/add/join-wallet/join-wallet.ts
+++ b/src/pages/add/join-wallet/join-wallet.ts
@@ -1,11 +1,10 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
-import { App, Events, NavController, NavParams } from 'ionic-angular';
+import { Events, NavController, NavParams } from 'ionic-angular';
 
 // Pages
 import { ScanPage } from '../../scan/scan';
-import { TabsPage } from '../../tabs/tabs';
 
 // Providers
 import { ActionSheetProvider } from '../../../providers/action-sheet/action-sheet';
@@ -42,7 +41,6 @@ export class JoinWalletPage {
   private coin: Coin;
 
   constructor(
-    private app: App,
     private bwcProvider: BwcProvider,
     private configProvider: ConfigProvider,
     private form: FormBuilder,
@@ -238,12 +236,11 @@ export class JoinWalletPage {
         this.onGoingProcessProvider.clear();
         this.walletProvider.updateRemotePreferences(wallet);
         this.pushNotificationsProvider.updateSubscription(wallet);
-        this.app
-          .getRootNavs()[0]
-          .setRoot(TabsPage)
-          .then(() => {
+        this.navCtrl.popToRoot().then(() => {
+          setTimeout(() => {
             this.events.publish('OpenWallet', wallet);
-          });
+          }, 1000);
+        });
       })
       .catch(err => {
         this.onGoingProcessProvider.clear();

--- a/src/pages/add/join-wallet/join-wallet.ts
+++ b/src/pages/add/join-wallet/join-wallet.ts
@@ -15,6 +15,7 @@ import { ConfigProvider } from '../../../providers/config/config';
 import { DerivationPathHelperProvider } from '../../../providers/derivation-path-helper/derivation-path-helper';
 import { Logger } from '../../../providers/logger/logger';
 import { OnGoingProcessProvider } from '../../../providers/on-going-process/on-going-process';
+import { PlatformProvider } from '../../../providers/platform/platform';
 import { PopupProvider } from '../../../providers/popup/popup';
 import { ProfileProvider } from '../../../providers/profile/profile';
 import { PushNotificationsProvider } from '../../../providers/push-notifications/push-notifications';
@@ -35,6 +36,7 @@ export class JoinWalletPage {
   public okText: string;
   public cancelText: string;
   public joinForm: FormGroup;
+  public hideConfirm: boolean;
 
   private derivationPathByDefault: string;
   private derivationPathForTestnet: string;
@@ -58,7 +60,8 @@ export class JoinWalletPage {
     private events: Events,
     private pushNotificationsProvider: PushNotificationsProvider,
     private actionSheetProvider: ActionSheetProvider,
-    private clipboardProvider: ClipboardProvider
+    private clipboardProvider: ClipboardProvider,
+    private platformProvider: PlatformProvider
   ) {
     this.okText = this.translate.instant('Ok');
     this.cancelText = this.translate.instant('Cancel');
@@ -108,6 +111,15 @@ export class JoinWalletPage {
       let data: string = this.navParams.data.url;
       data = data.replace('copay:', '');
       this.onQrCodeScannedJoin(data);
+    }
+    if (this.platformProvider.isCordova) {
+      window.addEventListener('keyboardWillShow', () => {
+        this.hideConfirm = true;
+      });
+
+      window.addEventListener('keyboardWillHide', () => {
+        this.hideConfirm = false;
+      });
     }
   }
 

--- a/src/pages/integrations/coinbase/coinbase-settings/coinbase-settings.ts
+++ b/src/pages/integrations/coinbase/coinbase-settings/coinbase-settings.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { App, NavController } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
 import * as _ from 'lodash';
 
@@ -9,7 +9,6 @@ import { ConfigProvider } from '../../../../providers/config/config';
 import { HomeIntegrationsProvider } from '../../../../providers/home-integrations/home-integrations';
 import { Logger } from '../../../../providers/logger/logger';
 import { PopupProvider } from '../../../../providers/popup/popup';
-import { TabsPage } from '../../../tabs/tabs';
 
 @Component({
   selector: 'page-coinbase-settings',
@@ -23,7 +22,6 @@ export class CoinbaseSettingsPage {
   public coinbaseUser;
 
   constructor(
-    private app: App,
     private navCtrl: NavController,
     private popupProvider: PopupProvider,
     private logger: Logger,
@@ -94,7 +92,7 @@ export class CoinbaseSettingsPage {
           this.coinbaseProvider.logout();
           this.showInHome = false;
           this.showInHomeSwitch();
-          this.app.getRootNavs()[0].setRoot(TabsPage);
+          this.navCtrl.popToRoot();
         }
       });
   }

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  App,
   Events,
   ModalController,
   NavController,
@@ -72,7 +71,6 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
 
   constructor(
     actionSheetProvider: ActionSheetProvider,
-    app: App,
     bwcErrorProvider: BwcErrorProvider,
     bwcProvider: BwcProvider,
     configProvider: ConfigProvider,
@@ -101,7 +99,6 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
   ) {
     super(
       actionSheetProvider,
-      app,
       bwcErrorProvider,
       bwcProvider,
       configProvider,

--- a/src/pages/integrations/shapeshift/shapeshift-settings/shapeshift-settings.ts
+++ b/src/pages/integrations/shapeshift/shapeshift-settings/shapeshift-settings.ts
@@ -1,10 +1,7 @@
 import { Component } from '@angular/core';
-import { App } from 'ionic-angular';
+import { NavController } from 'ionic-angular';
 
 import * as _ from 'lodash';
-
-// Pages
-import { TabsPage } from '../../../tabs/tabs';
 
 // Providers
 import { ConfigProvider } from '../../../../providers/config/config';
@@ -29,7 +26,7 @@ export class ShapeshiftSettingsPage {
   public loading: boolean;
 
   constructor(
-    private app: App,
+    private navCtrl: NavController,
     private popupProvider: PopupProvider,
     private logger: Logger,
     private shapeshiftProvider: ShapeshiftProvider,
@@ -87,7 +84,7 @@ export class ShapeshiftSettingsPage {
         if (res) {
           this.shapeshiftProvider.getStoredToken(accessToken => {
             this.shapeshiftProvider.logout(accessToken);
-            this.app.getRootNavs()[0].setRoot(TabsPage);
+            this.navCtrl.popToRoot();
           });
         }
       });

--- a/src/pages/integrations/shapeshift/shapeshift.ts
+++ b/src/pages/integrations/shapeshift/shapeshift.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  App,
   Events,
   ModalController,
   NavController,
@@ -11,7 +10,6 @@ import * as _ from 'lodash';
 import { Logger } from '../../../providers/logger/logger';
 
 // Pages
-import { TabsPage } from '../../tabs/tabs';
 import { ShapeshiftDetailsPage } from './shapeshift-details/shapeshift-details';
 import { ShapeshiftShiftPage } from './shapeshift-shift/shapeshift-shift';
 
@@ -38,7 +36,6 @@ export class ShapeshiftPage {
   public error: string;
 
   constructor(
-    private app: App,
     private events: Events,
     private externalLinkProvider: ExternalLinkProvider,
     private logger: Logger,
@@ -108,7 +105,7 @@ export class ShapeshiftPage {
                 )
                 .then(() => {
                   this.shapeshiftProvider.logout(this.accessToken);
-                  this.app.getRootNavs()[0].setRoot(TabsPage);
+                  this.navCtrl.popToRoot();
                 });
             }
           }
@@ -221,7 +218,7 @@ export class ShapeshiftPage {
     this.externalLinkProvider
       .open(url, optIn, title, message, okText, cancelText)
       .then(() => {
-        this.app.getRootNavs()[0].setRoot(TabsPage);
+        this.navCtrl.popToRoot();
       });
   }
 

--- a/src/pages/paper-wallet/paper-wallet.ts
+++ b/src/pages/paper-wallet/paper-wallet.ts
@@ -1,11 +1,10 @@
 import { Component, ViewChild } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { App, ModalController, NavController, NavParams } from 'ionic-angular';
+import { ModalController, NavController, NavParams } from 'ionic-angular';
 import * as _ from 'lodash';
 
 // pages
 import { FinishModalPage } from '../finish/finish';
-import { TabsPage } from '../tabs/tabs';
 
 // providers
 import { ActionSheetProvider } from '../../providers/action-sheet/action-sheet';
@@ -50,7 +49,6 @@ export class PaperWalletPage {
   public isCordova: boolean;
 
   constructor(
-    private app: App,
     private actionSheetProvider: ActionSheetProvider,
     private navCtrl: NavController,
     private navParams: NavParams,
@@ -328,7 +326,7 @@ export class PaperWalletPage {
     );
     modal.present();
     modal.onDidDismiss(() => {
-      this.app.getRootNavs()[0].setRoot(TabsPage);
+      this.navCtrl.popToRoot();
     });
   }
 }

--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -2,7 +2,6 @@ import { DecimalPipe } from '@angular/common';
 import { Component, ViewChild } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  App,
   Events,
   ModalController,
   NavController,
@@ -13,7 +12,6 @@ import { Logger } from '../../../providers/logger/logger';
 
 // Pages
 import { FinishModalPage } from '../../finish/finish';
-import { TabsPage } from '../../tabs/tabs';
 import { ChooseFeeLevelPage } from '../choose-fee-level/choose-fee-level';
 
 // Providers
@@ -89,7 +87,6 @@ export class ConfirmPage extends WalletTabsChild {
 
   constructor(
     protected actionSheetProvider: ActionSheetProvider,
-    protected app: App,
     protected bwcErrorProvider: BwcErrorProvider,
     protected bwcProvider: BwcProvider,
     protected configProvider: ConfigProvider,
@@ -728,7 +725,7 @@ export class ConfirmPage extends WalletTabsChild {
       if (option || typeof option === 'undefined') {
         this.isWithinWalletTabs()
           ? this.navCtrl.pop()
-          : this.app.getRootNavs()[0].setRoot(TabsPage);
+          : this.navCtrl.popToRoot();
       } else {
         this.tx.sendMax = true;
         this.setWallet(this.wallet);
@@ -765,7 +762,7 @@ export class ConfirmPage extends WalletTabsChild {
           ? this.navCtrl.popToRoot()
           : this.navCtrl.last().name == 'ConfirmCardPurchasePage'
           ? this.navCtrl.pop()
-          : this.app.getRootNavs()[0].setRoot(TabsPage);
+          : this.navCtrl.popToRoot();
       }
     });
   }
@@ -904,8 +901,11 @@ export class ConfirmPage extends WalletTabsChild {
         this.events.publish('OpenWallet', this.wallet);
       });
     } else {
-      this.app.getRootNavs()[0].setRoot(TabsPage);
-      this.events.publish('OpenWallet', this.wallet);
+      this.navCtrl.popToRoot().then(() => {
+        setTimeout(() => {
+          this.events.publish('OpenWallet', this.wallet);
+        }, 1000);
+      });
     }
   }
 


### PR DESCRIPTION
* Fix import that could freeze the app after 2 or 3 wallets imported.
* Remove buttons from create/join/import views due to incompatibility with virtual keyboard on iOS. Moved to top-right.