### PR TITLE
Order card brands starting with numbers last

### DIFF
--- a/src/providers/gift-card/gift-card.ts
+++ b/src/providers/gift-card/gift-card.ts
@@ -650,8 +650,8 @@ export function sortByDisplayName(
   const startsNumeric = value => /^[0-9]$/.test(value.charAt(0));
   const aName = a.displayName.toLowerCase();
   const bName = b.displayName.toLowerCase();
-  const aSortValue = `${startsNumeric(aName) ? 'z' : ''}${aName}`;
-  const bSortValue = `${startsNumeric(bName) ? 'z' : ''}${bName}`;
+  const aSortValue = `${startsNumeric(aName) ? 'zzz' : ''}${aName}`;
+  const bSortValue = `${startsNumeric(bName) ? 'zzz' : ''}${bName}`;
   return aSortValue > bSortValue ? 1 : -1;
 }
 


### PR DESCRIPTION
Ensure brands that start with numbers are always listed last.