### PR TITLE
Feature/setCoinConfig

### DIFF
--- a/src/pages/integrations/shapeshift/shapeshift-confirm/shapeshift-confirm.ts
+++ b/src/pages/integrations/shapeshift/shapeshift-confirm/shapeshift-confirm.ts
@@ -461,7 +461,7 @@ export class ShapeshiftConfirmPage {
 
   private showSendMaxWarning(): Promise<any> {
     return new Promise(resolve => {
-      let fee = this.sendMaxInfo.fee / 1e8;
+      let fee = this.sendMaxInfo.fee / this.configWallet.settings.unitToSatoshi;
       let msg = this.replaceParametersProvider.replace(
         this.translate.instant(
           '{{fee}} {{coin}} will be deducted for bitcoin networking fees.'
@@ -481,7 +481,9 @@ export class ShapeshiftConfirmPage {
   private verifyExcludedUtxos() {
     let warningMsg = [];
     if (this.sendMaxInfo.utxosBelowFee > 0) {
-      let amountBelowFeeStr = this.sendMaxInfo.amountBelowFee / 1e8;
+      let amountBelowFeeStr =
+        this.sendMaxInfo.amountBelowFee /
+        this.configWallet.settings.unitToSatoshi;
       let message = this.replaceParametersProvider.replace(
         this.translate.instant(
           'A total of {{fee}} {{coin}} were excluded. These funds come from UTXOs smaller than the network fee provided.'
@@ -492,7 +494,9 @@ export class ShapeshiftConfirmPage {
     }
 
     if (this.sendMaxInfo.utxosAboveMaxSize > 0) {
-      let amountAboveMaxSizeStr = this.sendMaxInfo.amountAboveMaxSize / 1e8;
+      let amountAboveMaxSizeStr =
+        this.sendMaxInfo.amountAboveMaxSize /
+        this.configWallet.settings.unitToSatoshi;
       let message = this.replaceParametersProvider.replace(
         this.translate.instant(
           'A total of {{fee}} {{coin}} were excluded. The maximum size allowed for a transaction was exceeded.'

--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -247,7 +247,10 @@ export class ConfirmPage extends WalletTabsChild {
   }
 
   private getAmountDetails() {
-    this.amount = this.decimalPipe.transform(this.tx.amount / 1e8, '1.2-6');
+    this.amount = this.decimalPipe.transform(
+      this.tx.amount / this.config.wallet.settings.unitToSatoshi,
+      '1.2-6'
+    );
   }
 
   private afterWalletSelectorSet() {
@@ -612,7 +615,7 @@ export class ConfirmPage extends WalletTabsChild {
       'miner-fee-notice',
       {
         coinName,
-        fee: sendMaxInfo.fee / 1e8,
+        fee: sendMaxInfo.fee / this.config.wallet.settings.unitToSatoshi,
         coin: this.tx.coin.toUpperCase(),
         msg: !_.isEmpty(warningMsg) ? warningMsg : ''
       }
@@ -623,7 +626,8 @@ export class ConfirmPage extends WalletTabsChild {
   private verifyExcludedUtxos(_, sendMaxInfo) {
     const warningMsg = [];
     if (sendMaxInfo.utxosBelowFee > 0) {
-      const amountBelowFeeStr = sendMaxInfo.amountBelowFee / 1e8;
+      const amountBelowFeeStr =
+        sendMaxInfo.amountBelowFee / this.config.wallet.settings.unitToSatoshi;
       const message = this.replaceParametersProvider.replace(
         this.translate.instant(
           'A total of {{amountBelowFeeStr}} {{coin}} were excluded. These funds come from UTXOs smaller than the network fee provided.'
@@ -634,7 +638,9 @@ export class ConfirmPage extends WalletTabsChild {
     }
 
     if (sendMaxInfo.utxosAboveMaxSize > 0) {
-      const amountAboveMaxSizeStr = sendMaxInfo.amountAboveMaxSize / 1e8;
+      const amountAboveMaxSizeStr =
+        sendMaxInfo.amountAboveMaxSize /
+        this.config.wallet.settings.unitToSatoshi;
       const message = this.replaceParametersProvider.replace(
         this.translate.instant(
           'A total of {{amountAboveMaxSizeStr}} {{coin}} were excluded. The maximum size allowed for a transaction was exceeded.'
@@ -827,7 +833,9 @@ export class ConfirmPage extends WalletTabsChild {
         const amountUsd = parseFloat(val);
         if (amountUsd <= this.CONFIRM_LIMIT_USD) return resolve(false);
 
-        const amount = (this.tx.amount / 1e8).toFixed(8);
+        const amount = (
+          this.tx.amount / this.config.wallet.settings.unitToSatoshi
+        ).toFixed(8);
         const unit = txp.coin.toUpperCase();
         const name = wallet.name;
         const message = this.replaceParametersProvider.replace(

--- a/src/pages/send/multi-send/multi-send.ts
+++ b/src/pages/send/multi-send/multi-send.ts
@@ -14,6 +14,7 @@ import { ActionSheetProvider } from '../../../providers/action-sheet/action-shee
 import { AddressProvider } from '../../../providers/address/address';
 import { AppProvider } from '../../../providers/app/app';
 import { BwcProvider } from '../../../providers/bwc/bwc';
+import { ConfigProvider } from '../../../providers/config/config';
 import { ExternalLinkProvider } from '../../../providers/external-link/external-link';
 import { IncomingDataProvider } from '../../../providers/incoming-data/incoming-data';
 import { Logger } from '../../../providers/logger/logger';
@@ -46,6 +47,7 @@ export class MultiSendPage extends WalletTabsChild {
   public invalidAddress: boolean;
   public isDisabledContinue: boolean;
 
+  private unitToSatoshi: number;
   private scannerOpened: boolean;
   private validDataTypeMap: string[] = [
     'BitcoinAddress',
@@ -58,6 +60,7 @@ export class MultiSendPage extends WalletTabsChild {
     navCtrl: NavController,
     private navParams: NavParams,
     profileProvider: ProfileProvider,
+    private configProvider: ConfigProvider,
     private logger: Logger,
     private incomingDataProvider: IncomingDataProvider,
     private addressProvider: AddressProvider,
@@ -74,6 +77,7 @@ export class MultiSendPage extends WalletTabsChild {
   ) {
     super(navCtrl, profileProvider, walletTabsProvider);
     this.isDisabledContinue = true;
+    this.unitToSatoshi = this.configProvider.get().wallet.settings.unitToSatoshi;
   }
 
   ionViewDidLoad() {
@@ -141,7 +145,7 @@ export class MultiSendPage extends WalletTabsChild {
       item.fiatAmount = data.fiatAmount;
       item.fiatCode = data.fiatCode;
       item.amountToShow = this.decimalPipe.transform(
-        data.amount / 1e8,
+        data.amount / this.unitToSatoshi,
         '1.2-6'
       );
       this.multiRecipients[index] = item;
@@ -151,7 +155,10 @@ export class MultiSendPage extends WalletTabsChild {
 
   public addRecipient(recipient): void {
     let amountToShow = +recipient.amount
-      ? this.decimalPipe.transform(+recipient.amount / 1e8, '1.2-6')
+      ? this.decimalPipe.transform(
+          +recipient.amount / this.unitToSatoshi,
+          '1.2-6'
+        )
       : null;
 
     let altAmountStr = this.txFormatProvider.formatAlternativeStr(

--- a/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-information/wallet-information.html
+++ b/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-information/wallet-information.html
@@ -82,7 +82,7 @@
     <ion-item class="item" *ngFor="let a of balanceByAddress" copy-to-clipboard="{{a.address}}">
       <span>{{a.address}}</span>
       <ion-note item-end>
-        {{(a.amount / unitToSatoshi).toFixed(8)}} BTC
+        {{(a.amount / unitToSatoshi).toFixed(8)}} {{coin.toUpperCase()}}
       </ion-note>
     </ion-item>
     <ion-item-divider></ion-item-divider>

--- a/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-information/wallet-information.html
+++ b/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-information/wallet-information.html
@@ -82,7 +82,7 @@
     <ion-item class="item" *ngFor="let a of balanceByAddress" copy-to-clipboard="{{a.address}}">
       <span>{{a.address}}</span>
       <ion-note item-end>
-        {{(a.amount/1e8).toFixed(8)}} BTC
+        {{(a.amount / unitToSatoshi).toFixed(8)}} BTC
       </ion-note>
     </ion-item>
     <ion-item-divider></ion-item-divider>

--- a/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-information/wallet-information.ts
+++ b/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-information/wallet-information.ts
@@ -3,6 +3,7 @@ import { NavParams } from 'ionic-angular';
 import * as _ from 'lodash';
 
 // providers
+import { ConfigProvider } from '../../../../../providers/config/config';
 import { Logger } from '../../../../../providers/logger/logger';
 import { ProfileProvider } from '../../../../../providers/profile/profile';
 
@@ -27,9 +28,11 @@ export class WalletInformationPage {
   public pubKeys;
   public externalSource: string;
   public canSign: boolean;
+  public unitToSatoshi: number;
 
   constructor(
     private profileProvider: ProfileProvider,
+    private configProvider: ConfigProvider,
     private navParams: NavParams,
     private logger: Logger
   ) {}
@@ -40,6 +43,7 @@ export class WalletInformationPage {
 
   ionViewWillEnter() {
     this.wallet = this.profileProvider.getWallet(this.navParams.data.walletId);
+    this.unitToSatoshi = this.configProvider.get().wallet.settings.unitToSatoshi;
     this.walletName = this.wallet.name;
     this.coin = this.wallet.coin;
     this.walletId = this.wallet.credentials.walletId;

--- a/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-transaction-history/wallet-transaction-history.ts
+++ b/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-transaction-history/wallet-transaction-history.ts
@@ -29,7 +29,6 @@ export class WalletTransactionHistoryPage {
   public unitToSatoshi: number;
   public unitDecimals: number;
   public satToUnit: number;
-  public satToBtc: number;
 
   private currency: string;
 
@@ -61,7 +60,6 @@ export class WalletTransactionHistoryPage {
     this.unitToSatoshi = this.config.wallet.settings.unitToSatoshi;
     this.unitDecimals = this.config.wallet.settings.unitDecimals;
     this.satToUnit = 1 / this.unitToSatoshi;
-    this.satToBtc = 1 / 100000000;
     this.csvHistory();
   }
 
@@ -127,12 +125,12 @@ export class WalletTransactionHistoryPage {
           }
           _amount =
             (it.action == 'sent' ? '-' : '') +
-            (amount * this.satToBtc).toFixed(8);
+            (amount * this.satToUnit).toFixed(8);
           _note = it.message || '';
           _comment = it.note ? it.note.body : '';
 
           if (it.action == 'moved')
-            _note += ' Moved:' + (it.amount * this.satToBtc).toFixed(8);
+            _note += ' Moved:' + (it.amount * this.satToUnit).toFixed(8);
 
           this.csvContent.push({
             Date: this.formatDate(it.time * 1000),
@@ -147,7 +145,7 @@ export class WalletTransactionHistoryPage {
           });
 
           if (it.fees && (it.action == 'moved' || it.action == 'sent')) {
-            const _fee = (it.fees * this.satToBtc).toFixed(8);
+            const _fee = (it.fees * this.satToUnit).toFixed(8);
             this.csvContent.push({
               Date: this.formatDate(it.time * 1000),
               Destination: 'Bitcoin Network Fees',

--- a/src/pages/txp-details/txp-details.ts
+++ b/src/pages/txp-details/txp-details.ts
@@ -120,7 +120,10 @@ export class TxpDetailsPage {
     this.checkPaypro();
     this.applyButtonText();
 
-    this.amount = this.decimalPipe.transform(this.tx.amount / 1e8, '1.2-6');
+    this.amount = this.decimalPipe.transform(
+      this.tx.amount / this.configProvider.get().wallet.settings.unitToSatoshi,
+      '1.2-6'
+    );
   }
 
   ionViewWillLoad() {

--- a/src/pipes/fiatToUnit.ts
+++ b/src/pipes/fiatToUnit.ts
@@ -27,7 +27,10 @@ export class FiatToUnitPipe implements PipeTransform {
       coin.toLowerCase()
     );
     return (
-      this.decimalPipe.transform(amount_ / 1e8 || 0, '1.2-8') +
+      this.decimalPipe.transform(
+        amount_ / this.walletSettings.unitToSatoshi || 0,
+        '1.2-8'
+      ) +
       ' ' +
       coin.toUpperCase()
     );

--- a/src/pipes/satToUnit.ts
+++ b/src/pipes/satToUnit.ts
@@ -1,15 +1,20 @@
 import { DecimalPipe } from '@angular/common';
 import { Pipe, PipeTransform } from '@angular/core';
+import { ConfigProvider } from '../providers/config/config';
 
 @Pipe({
   name: 'satToUnit',
   pure: false
 })
 export class SatToUnitPipe implements PipeTransform {
-  constructor(private decimalPipe: DecimalPipe) {}
+  constructor(
+    private decimalPipe: DecimalPipe,
+    private configProvider: ConfigProvider
+  ) {}
   transform(amount: number, coin: string) {
+    const { unitToSatoshi } = this.configProvider.get().wallet.settings;
     return (
-      this.decimalPipe.transform(amount / 1e8, '1.2-6') +
+      this.decimalPipe.transform(amount / unitToSatoshi, '1.2-6') +
       ' ' +
       coin.toUpperCase()
     );

--- a/src/providers/config/config.ts
+++ b/src/providers/config/config.ts
@@ -4,6 +4,12 @@ import { PersistenceProvider } from '../persistence/persistence';
 
 import * as _ from 'lodash';
 
+export interface CoinOpts {
+  btc: Partial<Config['wallet']['settings']>;
+  bch: Partial<Config['wallet']['settings']>;
+  eth: Partial<Config['wallet']['settings']>;
+}
+
 export interface Config {
   limits: {
     totalCopayers: number;
@@ -102,12 +108,33 @@ export interface Config {
 export class ConfigProvider {
   public configCache: Config;
   public readonly configDefault: Config;
+  public readonly coinOpts: CoinOpts;
 
   constructor(
     private logger: Logger,
     private persistence: PersistenceProvider
   ) {
     this.logger.debug('ConfigProvider initialized');
+    this.coinOpts = {
+      btc: {
+        unitName: 'BTC',
+        unitToSatoshi: 100000000,
+        unitDecimals: 8,
+        unitCode: 'btc'
+      },
+      bch: {
+        unitName: 'BTC',
+        unitToSatoshi: 100000000,
+        unitDecimals: 8,
+        unitCode: 'btc'
+      },
+      eth: {
+        unitName: 'ETH',
+        unitToSatoshi: 1e18,
+        unitDecimals: 18,
+        unitCode: 'eth'
+      }
+    };
     this.configDefault = {
       // wallet limits
       limits: {
@@ -251,6 +278,10 @@ export class ConfigProvider {
     this.persistence.storeConfig(this.configCache).then(() => {
       this.logger.info('Config saved');
     });
+  }
+
+  public getCoinOpts(coin: string) {
+    return this.coinOpts[coin];
   }
 
   public get(): Config {

--- a/src/providers/profile/profile.ts
+++ b/src/providers/profile/profile.ts
@@ -642,6 +642,7 @@ export class ProfileProvider {
 
     await this.bindWalletClient(wallet);
 
+    this.saveCoinConfig(wallet.coin);
     this.saveBwsUrl(walletId, opts);
 
     return this.storeProfileIfDirty().then(() => {
@@ -661,6 +662,16 @@ export class ProfileProvider {
     }
 
     this.configProvider.set({ bwsFor });
+  }
+
+  private saveCoinConfig(coin: string): void {
+    const coinOpts = this.configProvider.getCoinOpts(coin);
+    const newOpts = {
+      wallet: {
+        settings: coinOpts
+      }
+    };
+    this.configProvider.set(newOpts);
   }
 
   private shouldSkipValidation(walletId: string): boolean {

--- a/src/providers/tx-format/tx-format.ts
+++ b/src/providers/tx-format/tx-format.ts
@@ -171,14 +171,18 @@ export class TxFormatProvider {
     onlyIntegers?: boolean
   ) {
     let settings = this.configProvider.get().wallet.settings;
-    let satToBtc = 1 / 100000000;
     let unitToSatoshi = settings.unitToSatoshi;
     let amountUnitStr;
     let amountSat;
     let alternativeIsoCode = settings.alternativeIsoCode;
 
     // If fiat currency
-    if (currency != 'BCH' && currency != 'BTC' && currency != 'sat') {
+    if (
+      currency != 'BCH' &&
+      currency != 'BTC' &&
+      currency != 'ETH' &&
+      currency != 'sat'
+    ) {
       let formattedAmount = onlyIntegers
         ? this.filter.formatFiatAmount(amount.toFixed(0))
         : this.filter.formatFiatAmount(amount);
@@ -188,13 +192,13 @@ export class TxFormatProvider {
       amountSat = Number(amount);
       amountUnitStr = this.formatAmountStr(coin, amountSat);
       // convert sat to BTC or BCH
-      amount = (amountSat * satToBtc).toFixed(8);
+      amount = (amountSat * unitToSatoshi).toFixed(8);
       currency = coin.toUpperCase();
     } else {
       amountSat = parseInt((amount * unitToSatoshi).toFixed(0), 10);
       amountUnitStr = this.formatAmountStr(coin, amountSat);
       // convert unit to BTC or BCH
-      amount = (amountSat * satToBtc).toFixed(8);
+      amount = (amountSat * unitToSatoshi).toFixed(8);
       currency = coin.toUpperCase();
     }
 

--- a/src/providers/tx-format/tx-format.ts
+++ b/src/providers/tx-format/tx-format.ts
@@ -178,12 +178,7 @@ export class TxFormatProvider {
     let alternativeIsoCode = settings.alternativeIsoCode;
 
     // If fiat currency
-    if (
-      currency != 'BCH' &&
-      currency != 'BTC' &&
-      currency != 'ETH' &&
-      currency != 'sat'
-    ) {
+    if (currency != 'BCH' && currency != 'BTC' && currency != 'sat') {
       let formattedAmount = onlyIntegers
         ? this.filter.formatFiatAmount(amount.toFixed(0))
         : this.filter.formatFiatAmount(amount);

--- a/src/providers/tx-format/tx-format.ts
+++ b/src/providers/tx-format/tx-format.ts
@@ -147,8 +147,8 @@ export class TxFormatProvider {
     tx.feeStr = tx.fee
       ? this.formatAmountStr(coin, tx.fee)
       : tx.fees
-      ? this.formatAmountStr(coin, tx.fees)
-      : 'N/A';
+        ? this.formatAmountStr(coin, tx.fees)
+        : 'N/A';
     if (tx.amountStr) {
       tx.amountValueStr = tx.amountStr.split(' ')[0];
       tx.amountUnitStr = tx.amountStr.split(' ')[1];
@@ -171,6 +171,7 @@ export class TxFormatProvider {
     onlyIntegers?: boolean
   ) {
     let settings = this.configProvider.get().wallet.settings;
+    let satToBtc = 1 / 100000000;
     let unitToSatoshi = settings.unitToSatoshi;
     let amountUnitStr;
     let amountSat;
@@ -192,13 +193,13 @@ export class TxFormatProvider {
       amountSat = Number(amount);
       amountUnitStr = this.formatAmountStr(coin, amountSat);
       // convert sat to BTC or BCH
-      amount = (amountSat * unitToSatoshi).toFixed(8);
+      amount = (amountSat * satToBtc).toFixed(8);
       currency = coin.toUpperCase();
     } else {
       amountSat = parseInt((amount * unitToSatoshi).toFixed(0), 10);
       amountUnitStr = this.formatAmountStr(coin, amountSat);
       // convert unit to BTC or BCH
-      amount = (amountSat * unitToSatoshi).toFixed(8);
+      amount = (amountSat * satToBtc).toFixed(8);
       currency = coin.toUpperCase();
     }
 

--- a/src/providers/tx-format/tx-format.ts
+++ b/src/providers/tx-format/tx-format.ts
@@ -170,7 +170,7 @@ export class TxFormatProvider {
     currency: string,
     onlyIntegers?: boolean
   ) {
-    let {
+    const {
       unitToSatoshi,
       alternativeIsoCode
     } = this.configProvider.get().wallet.settings;

--- a/src/providers/tx-format/tx-format.ts
+++ b/src/providers/tx-format/tx-format.ts
@@ -147,8 +147,8 @@ export class TxFormatProvider {
     tx.feeStr = tx.fee
       ? this.formatAmountStr(coin, tx.fee)
       : tx.fees
-        ? this.formatAmountStr(coin, tx.fees)
-        : 'N/A';
+      ? this.formatAmountStr(coin, tx.fees)
+      : 'N/A';
     if (tx.amountStr) {
       tx.amountValueStr = tx.amountStr.split(' ')[0];
       tx.amountUnitStr = tx.amountStr.split(' ')[1];

--- a/src/providers/tx-format/tx-format.ts
+++ b/src/providers/tx-format/tx-format.ts
@@ -170,11 +170,13 @@ export class TxFormatProvider {
     currency: string,
     onlyIntegers?: boolean
   ) {
-    let settings = this.configProvider.get().wallet.settings;
-    let unitToSatoshi = settings.unitToSatoshi;
+    let {
+      unitToSatoshi,
+      alternativeIsoCode
+    } = this.configProvider.get().wallet.settings;
+    const satToUnit = 1 / unitToSatoshi;
     let amountUnitStr;
     let amountSat;
-    let alternativeIsoCode = settings.alternativeIsoCode;
 
     // If fiat currency
     if (
@@ -192,13 +194,13 @@ export class TxFormatProvider {
       amountSat = Number(amount);
       amountUnitStr = this.formatAmountStr(coin, amountSat);
       // convert sat to BTC or BCH
-      amount = (amountSat * unitToSatoshi).toFixed(8);
+      amount = (amountSat * satToUnit).toFixed(8);
       currency = coin.toUpperCase();
     } else {
       amountSat = parseInt((amount * unitToSatoshi).toFixed(0), 10);
       amountUnitStr = this.formatAmountStr(coin, amountSat);
       // convert unit to BTC or BCH
-      amount = (amountSat * unitToSatoshi).toFixed(8);
+      amount = (amountSat * satToUnit).toFixed(8);
       currency = coin.toUpperCase();
     }
 

--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -30,7 +30,8 @@ export interface HistoryOptionsI {
 
 export enum Coin {
   BTC = 'btc',
-  BCH = 'bch'
+  BCH = 'bch',
+  ETH = 'eth'
 }
 
 export interface WalletOptions {


### PR DESCRIPTION
- Will bind/update new config on wallet create or import.
- Added coinOpts object to map wallet.coin to conversion units
- added getCoinOpts function
- replaces all hard coded `1e8` with `config.wallet.settings.unitToSatoshi`