### PR TITLE
fix(electron-builder): Upgrade deprecated method to build the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ yarn.lock
 cache
 dist/*
 electron/afterPack.js
+electron/build-electron.js
 *-embedded.provisionprofile
 *-entitlements.mas.plist
 

--- a/app-template/apply.js
+++ b/app-template/apply.js
@@ -11,6 +11,7 @@ const templates = {
   'config-template.xml': '/',
   'ionic.config-template.json': '/',
   'manifest.ionic-template.json': 'src/',
+  'build-electron-template.js': 'electron/',
   'afterPack-template.js': 'electron/'
 };
 
@@ -57,6 +58,8 @@ Object.keys(templates).forEach(function(k) {
     k = 'manifest.json';
   } else if (k === 'afterPack-template.js') {
     k = 'afterPack.js';
+  } else if (k === 'build-electron-template.js') {
+    k = 'build-electron.js';
   }
 
   if (!fs.existsSync('../' + targetDir)) {
@@ -140,23 +143,6 @@ package.repository.url = config.gitHubRepoUrl;
 package.bugs.url = config.gitHubRepoBugs;
 package.cordova.plugins['cordova-plugin-customurlscheme-ng'].SECOND_URL_SCHEME =
   config.packageName;
-package.build.appId = config.packageNameIdDesktop;
-package.build.productName = config.userVisibleName;
-package.build.mas.entitlements =
-  './' + config.packageName + '-entitlements.mas.plist';
-package.build.mas.provisioningProfile =
-  './' + config.packageName + '-embedded.provisionprofile';
-package.build.appx.identityName = config.WindowsStoreIdentityName;
-package.build.appx.applicationId = config.WindowsApplicationId;
-package.build.appx.displayName = config.WindowsStoreDisplayName;
-package.build.protocols.schemes = [
-  'bitcoin',
-  'bitcoincash',
-  'bchtest',
-  config.name
-];
-package.build.mac.icon = `resources/${config.name}/mac/app.icns`;
-package.build.win.icon = `resources/${config.name}/windows/icon.ico`;
 
 const stringifiedNpmStyle = JSON.stringify(package, null, 2) + '\n';
 fs.writeFileSync('../package.json', stringifiedNpmStyle);

--- a/app-template/build-electron-template.js
+++ b/app-template/build-electron-template.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const builder = require('electron-builder');
+
+builder
+  .build({
+    mac: ['mas'],
+    linux: ['snap'],
+    win: ['appx'],
+    config: {
+      appId: '*PACKAGENAMEIDDESKTOP*',
+      productName: '*USERVISIBLENAME*',
+      afterPack: './electron/afterPack.js',
+      files: [
+        './electron/main.js',
+        './package.json',
+        './www/**/*',
+        './build',
+        '!./node_modules/.cache/',
+        '!./**/*.map'
+      ],
+      protocols: {
+        name: 'URL protocol schemes',
+        schemes: ['bitcoin', 'bitcoincash', 'bchtest', '*NAME*']
+      },
+      mac: {
+        category: 'public.app-category.finance',
+        icon: 'resources/*NAME*/mac/app.icns',
+        artifactName: '*USERVISIBLENAME*.pkg',
+        darkModeSupport: false,
+        extendInfo: {
+          NSCameraUsageDescription:
+            'Scan a Bitcoin Address directly to your Wallet and send funds to it'
+        },
+        target: ['mas']
+      },
+      mas: {
+        identity: 'BitPay, Inc. (884JRH5R93)',
+        entitlements: './*PACKAGENAME*-entitlements.mas.plist',
+        provisioningProfile: './*PACKAGENAME*-embedded.provisionprofile'
+      },
+      win: {
+        target: ['appx'],
+        icon: 'resources/*NAME*/windows/icon.ico',
+        artifactName: '*USERVISIBLENAME*.appx'
+      },
+      appx: {
+        identityName: '*WINDOWSSTOREIDENTITYNAME*',
+        publisher: 'CN=F89609D1-EB3E-45FD-A58A-C2E3895FCE7B',
+        publisherDisplayName: 'BitPay Inc.',
+        applicationId: '*WINDOWSAPPLICATIONID*',
+        displayName: '*WINDOWSSTOREDISPLAYNAME*'
+      },
+      linux: {
+        target: ['snap'],
+        artifactName: '*USERVISIBLENAME*-linux.snap'
+      }
+    }
+  })
+  .then(() => {
+    // handle result
+    console.log('Build OK!');
+  })
+  .catch(error => {
+    // handle error
+    console.log(error);
+  });

--- a/package.json
+++ b/package.json
@@ -62,11 +62,12 @@
     "build:ios-release": "npm run env:prod && ionic cordova build ios --release --aot true --environment prod --output-hashing all --sourcemaps false --extract-css true --named-chunks false --build-optimizer true",
     "build:android-release": "npm run env:prod && ionic cordova build android --release --aot true --environment prod --output-hashing all --sourcemaps false --extract-css true --named-chunks false --build-optimizer true",
     "build:desktop-release": "npm run env:prod && node --max-old-space-size=8192 ./node_modules/@ionic/app-scripts/bin/ionic-app-scripts.js build --prod",
+    "build:electron": "node ./electron/build-electron.js",
     "open:ios": "open platforms/ios/*.xcodeproj",
     "open:android": "open -a open -a /Applications/Android\\ Studio.app platforms/android",
     "final:ios": "npm run build:ios-release && npm run open:ios",
     "final:android": "npm run build:android-release && npm run sign:android && npm run run:android-release",
-    "final:desktop": "npm run build:desktop-release && electron-builder -mwl",
+    "final:desktop": "npm run build:desktop-release && npm run build:electron",
     "run:android": "npm run env:dev && ionic cordova run android --device --debug",
     "run:android-release": "npm run env:prod && ionic cordova run android --device --release",
     "log:android": "adb logcat | grep chromium",
@@ -84,65 +85,6 @@
     "sign:bitpay-linux": "gpg -u 1112CFA1 --output dist/BitPay-linux.zip.sig --detach-sig dist/BitPay-linux.zip",
     "sign:bitpay-windows": "gpg -u 1112CFA1 --output dist/BitPay.exe.sig --detach-sig dist/BitPay.exe",
     "verify:bitpay-desktop": "gpg --verify dist/BitPay-linux.zip.sig dist/BitPay-linux.zip; gpg --verify dist/BitPay.exe.sig dist/BitPay.exe; gpg --verify dist/BitPay.dmg.sig dist/BitPay.dmg"
-  },
-  "build": {
-    "appId": "com.bitpay.copay.desktop2",
-    "productName": "Copay",
-    "afterPack": "./electron/afterPack.js",
-    "files": [
-      "./electron/main.js",
-      "./package.json",
-      "./www/**/*",
-      "./build",
-      "!node_modules/.cache/",
-      "!**/*.map"
-    ],
-    "protocols": {
-      "name": "URL protocol schemes",
-      "schemes": [
-        "bitcoin",
-        "bitcoincash",
-        "bchtest",
-        "copay"
-      ]
-    },
-    "mac": {
-      "category": "public.app-category.finance",
-      "icon": "resources/copay/mac/app.icns",
-      "artifactName": "${productName}.${ext}",
-      "darkModeSupport": false,
-      "extendInfo": {
-        "NSCameraUsageDescription": "Scan a Bitcoin Address directly to your Wallet and send funds to it"
-      },
-      "target": [
-        "mas"
-      ]
-    },
-    "mas": {
-      "identity": "BitPay, Inc. (884JRH5R93)",
-      "entitlements": "./copay-entitlements.mas.plist",
-      "provisioningProfile": "./copay-embedded.provisionprofile"
-    },
-    "win": {
-      "target": [
-        "appx"
-      ],
-      "icon": "resources/copay/windows/icon.ico",
-      "artifactName": "${productName}.${ext}"
-    },
-    "appx": {
-      "identityName": "18C7659D.CopayforWindows",
-      "publisher": "CN=F89609D1-EB3E-45FD-A58A-C2E3895FCE7B",
-      "publisherDisplayName": "BitPay Inc.",
-      "applicationId": "CopayforWindows",
-      "displayName": "Copay for Windows"
-    },
-    "linux": {
-      "target": [
-        "snap"
-      ],
-      "artifactName": "${productName}-linux.${ext}"
-    }
   },
   "dependencies": {
     "@angular/animations": "5.2.10",


### PR DESCRIPTION
New versions of `electron-builder` uses JS API instead yards in package.json. 