### PR TITLE
test accounts when joinning a new wallet

### DIFF
--- a/src/providers/profile/profile.ts
+++ b/src/providers/profile/profile.ts
@@ -1200,7 +1200,7 @@ export class ProfileProvider {
               },
               err => {
                 const copayerRegistered =
-                  err instanceof this.errors.COPAYER_REGISTERED;
+                 err instanceof this.errors.COPAYER_REGISTERED;
                 const isSetSeed = opts.mnemonic || opts.extendedPrivateKey;
 
                 if (err && (!copayerRegistered || isSetSeed)) {
@@ -1273,11 +1273,23 @@ export class ProfileProvider {
             },
             err => {
               if (err) {
-                const msg = this.bwcErrorProvider.msg(
-                  err,
-                  this.translate.instant('Could not join wallet')
-                );
-                return reject(msg);
+                if (err instanceof this.errors.COPAYER_REGISTERED) {
+                  // try with account + 1
+                  opts.account = opts.account ? opts.account + 1 : 1;
+                  if (opts.account === 20)
+                    return reject(
+                      this.translate.instant(
+                        'You reach the limit of twenty wallets from the same coin and network'
+                      )
+                    );
+                  return resolve(this._joinWallet(opts));
+                } else {
+                  const msg = this.bwcErrorProvider.msg(
+                    err,
+                    this.translate.instant('Could not join wallet')
+                  );
+                  return reject(msg);
+                }
               }
               return resolve(data);
             }

--- a/src/providers/profile/profile.ts
+++ b/src/providers/profile/profile.ts
@@ -1200,7 +1200,7 @@ export class ProfileProvider {
               },
               err => {
                 const copayerRegistered =
-                 err instanceof this.errors.COPAYER_REGISTERED;
+                  err instanceof this.errors.COPAYER_REGISTERED;
                 const isSetSeed = opts.mnemonic || opts.extendedPrivateKey;
 
                 if (err && (!copayerRegistered || isSetSeed)) {


### PR DESCRIPTION
same logic of "create wallet" but for "join wallet": Test until a free account number is found.