### PR TITLE
Fix: go to "add wallet" before "join page" using the general scan

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -33,9 +33,9 @@ import { TouchIdProvider } from '../providers/touchid/touchid';
 
 // pages
 import { ImageLoaderConfig } from 'ionic-image-loader';
+import { AddWalletPage } from '../pages/add-wallet/add-wallet';
 import { CopayersPage } from '../pages/add/copayers/copayers';
 import { ImportWalletPage } from '../pages/add/import-wallet/import-wallet';
-import { JoinWalletPage } from '../pages/add/join-wallet/join-wallet';
 import { FingerprintModalPage } from '../pages/fingerprint/fingerprint';
 import { BitPayCardIntroPage } from '../pages/integrations/bitpay-card/bitpay-card-intro/bitpay-card-intro';
 import { CoinbasePage } from '../pages/integrations/coinbase/coinbase';
@@ -84,7 +84,7 @@ export class CopayApp {
     ConfirmPage,
     CopayersPage,
     ImportWalletPage,
-    JoinWalletPage,
+    AddWalletPage,
     PaperWalletPage,
     ShapeshiftPage,
     WalletDetailsPage,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,6 +36,7 @@ import { ImageLoaderConfig } from 'ionic-image-loader';
 import { AddWalletPage } from '../pages/add-wallet/add-wallet';
 import { CopayersPage } from '../pages/add/copayers/copayers';
 import { ImportWalletPage } from '../pages/add/import-wallet/import-wallet';
+import { JoinWalletPage } from '../pages/add/join-wallet/join-wallet';
 import { FingerprintModalPage } from '../pages/fingerprint/fingerprint';
 import { BitPayCardIntroPage } from '../pages/integrations/bitpay-card/bitpay-card-intro/bitpay-card-intro';
 import { CoinbasePage } from '../pages/integrations/coinbase/coinbase';
@@ -84,6 +85,7 @@ export class CopayApp {
     ConfirmPage,
     CopayersPage,
     ImportWalletPage,
+    JoinWalletPage,
     AddWalletPage,
     PaperWalletPage,
     ShapeshiftPage,

--- a/src/pages/add-wallet/add-wallet.ts
+++ b/src/pages/add-wallet/add-wallet.ts
@@ -57,7 +57,8 @@ export class AddWalletPage {
       });
     } else if (this.navParams.data.isJoin) {
       this.navCtrl.push(JoinWalletPage, {
-        keyId
+        keyId,
+        url: this.navParams.data.url ? this.navParams.data.url : null
       });
     }
   }

--- a/src/pages/add-wallet/add-wallet.ts
+++ b/src/pages/add-wallet/add-wallet.ts
@@ -58,7 +58,7 @@ export class AddWalletPage {
     } else if (this.navParams.data.isJoin) {
       this.navCtrl.push(JoinWalletPage, {
         keyId,
-        url: this.navParams.data.url ? this.navParams.data.url : null
+        url: this.navParams.data.url
       });
     }
   }

--- a/src/pages/add/add.ts
+++ b/src/pages/add/add.ts
@@ -23,17 +23,7 @@ export class AddPage {
     private logger: Logger,
     private configProvider: ConfigProvider,
     private profileProvider: ProfileProvider
-  ) {
-    const config = this.configProvider.get();
-    const opts2 = {
-      showHidden: true
-    };
-
-    const wallets2 = this.profileProvider.getWallets(opts2);
-    const nrKeys = _.values(_.groupBy(wallets2, 'keyId')).length;
-    this.allowMultiplePrimaryWallets =
-      config.allowMultiplePrimaryWallets || nrKeys != 1;
-  }
+  ) {}
 
   ionViewDidLoad() {
     this.logger.info('Loaded: AddPage');
@@ -44,50 +34,39 @@ export class AddPage {
     isJoin: boolean,
     isCreate: boolean
   ): void {
+    const config = this.configProvider.get();
     const opts = {
+      showHidden: true,
       canAddNewAccount: true
     };
-    const wallets = this.profileProvider.getWallets(opts);
-    const walletsGroups = _.values(_.groupBy(wallets, 'keyId'));
 
-    if (walletsGroups.length === 0) {
+    const wallets = this.profileProvider.getWallets(opts);
+    const nrKeys = _.values(_.groupBy(wallets, 'keyId')).length;
+    this.allowMultiplePrimaryWallets =
+      config.allowMultiplePrimaryWallets || nrKeys != 1;
+
+    if (nrKeys === 0) {
       this.goToNextPage(isCreate, isJoin, isShared);
-    } else if (
-      (this.allowMultiplePrimaryWallets && walletsGroups.length >= 1) ||
-      (!this.allowMultiplePrimaryWallets && walletsGroups.length > 1)
-    ) {
+    } else if (this.allowMultiplePrimaryWallets) {
       this.navCtrl.push(AddWalletPage, {
         isCreate,
         isJoin,
         isShared
       });
-    } else if (
-      !this.allowMultiplePrimaryWallets &&
-      walletsGroups.length === 1
-    ) {
-      this.goToNextPageWithKeyId(isCreate, isJoin, isShared, walletsGroups[0]);
+    } else if (!this.allowMultiplePrimaryWallets) {
+      this.goToNextPage(isCreate, isJoin, isShared, wallets[0].keyId);
     }
   }
 
-  private goToNextPage(isCreate, isJoin, isShared) {
-    if (isCreate) {
-      this.navCtrl.push(SelectCurrencyPage, {
-        isShared
-      });
-    } else if (isJoin) {
-      this.navCtrl.push(JoinWalletPage);
-    }
-  }
-
-  private goToNextPageWithKeyId(isCreate, isJoin, isShared, walletGroup) {
+  private goToNextPage(isCreate, isJoin, isShared, keyId?) {
     if (isCreate) {
       this.navCtrl.push(SelectCurrencyPage, {
         isShared,
-        keyId: walletGroup[0].credentials.keyId
+        keyId
       });
     } else if (isJoin) {
       this.navCtrl.push(JoinWalletPage, {
-        keyId: walletGroup[0].credentials.keyId
+        keyId
       });
     }
   }

--- a/src/pages/add/create-wallet/create-wallet.ts
+++ b/src/pages/add/create-wallet/create-wallet.ts
@@ -266,7 +266,7 @@ export class CreateWalletPage implements OnInit {
 
   private create(opts): void {
     this.onGoingProcessProvider.set('creatingWallet');
-    const addingNewWallet = this.keyId ? true : false;
+    const addingNewWallet = this.keyId ? true : false; // Adding new account to key
     this.profileProvider
       .createWallet(addingNewWallet, opts)
       .then(wallet => {

--- a/src/pages/add/join-wallet/join-wallet.ts
+++ b/src/pages/add/join-wallet/join-wallet.ts
@@ -65,7 +65,7 @@ export class JoinWalletPage {
     this.cancelText = this.translate.instant('Cancel');
     this.defaults = this.configProvider.getDefaults();
     this.showAdvOpts = false;
-    this.keyId = this.navParams.get('keyId');
+    this.keyId = this.navParams.data.keyId;
 
     this.regex = /^[0-9A-HJ-NP-Za-km-z]{70,80}$/; // For invitationCode
     this.joinForm = this.form.group({

--- a/src/pages/add/join-wallet/join-wallet.ts
+++ b/src/pages/add/join-wallet/join-wallet.ts
@@ -252,7 +252,7 @@ export class JoinWalletPage {
 
   private join(opts): void {
     this.onGoingProcessProvider.set('joiningWallet');
-    const addingNewWallet = this.keyId ? true : false;
+    const addingNewWallet = this.keyId ? true : false; // Adding new account to key
     this.profileProvider
       .joinWallet(addingNewWallet, opts)
       .then(wallet => {

--- a/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-duplicate/wallet-duplicate.ts
+++ b/src/pages/settings/wallet-settings/wallet-settings-advanced/wallet-duplicate/wallet-duplicate.ts
@@ -211,7 +211,7 @@ export class WalletDuplicatePage {
           } else {
             opts.extendedPrivateKey = keys.xPrivKey;
             opts.useLegacyCoinType = true;
-            const addingNewWallet = false;
+            const addingNewWallet = false; // Adding new account to key
             return this.profileProvider
               .createWallet(addingNewWallet, opts)
               .then(walletBch => {

--- a/src/providers/incoming-data/incoming-data.spec.ts
+++ b/src/providers/incoming-data/incoming-data.spec.ts
@@ -95,9 +95,9 @@ describe('Provider: Incoming Data Provider', () => {
     it('Should handle Join Wallet', () => {
       let data =
         'copay:RTpopkn5KBnkxuT7x4ummDKx3Lu1LvbntddBC4ssDgaqP7DkojT8ccxaFQEXY4f3huFyMewhHZLbtc';
-      let stateParams = { url: data, fromScan: true };
+      let stateParams = { url: data, isJoin: true };
       let nextView = {
-        name: 'JoinWalletPage',
+        name: 'AddWalletPage',
         params: stateParams
       };
 
@@ -112,9 +112,9 @@ describe('Provider: Incoming Data Provider', () => {
     it('Should handle Old Join Wallet', () => {
       let data =
         'RTpopkn5KBnkxuT7x4ummDKx3Lu1LvbntddBC4ssDgaqP7DkojT8ccxaFQEXY4f3huFyMewhHZLbtc';
-      let stateParams = { url: data, fromScan: true };
+      let stateParams = { url: data, isJoin: true };
       let nextView = {
-        name: 'JoinWalletPage',
+        name: 'AddWalletPage',
         params: stateParams
       };
 
@@ -133,7 +133,7 @@ describe('Provider: Incoming Data Provider', () => {
         '3|'
       ];
       data.forEach(element => {
-        let stateParams = { code: element, fromScan: true };
+        let stateParams = { code: element };
         let nextView = {
           name: 'ImportWalletPage',
           params: stateParams

--- a/src/providers/incoming-data/incoming-data.spec.ts
+++ b/src/providers/incoming-data/incoming-data.spec.ts
@@ -9,7 +9,7 @@ import { Logger } from '../logger/logger';
 import { ProfileProvider } from '../profile/profile';
 import { IncomingDataProvider } from './incoming-data';
 
-fdescribe('Provider: Incoming Data Provider', () => {
+describe('Provider: Incoming Data Provider', () => {
   let incomingDataProvider: IncomingDataProvider;
   let bwcProvider: BwcProvider;
   let logger: Logger;

--- a/src/providers/incoming-data/incoming-data.spec.ts
+++ b/src/providers/incoming-data/incoming-data.spec.ts
@@ -4,10 +4,12 @@ import { AppProvider, PopupProvider } from '..';
 import { TestUtils } from '../../test';
 import { ActionSheetProvider } from '../action-sheet/action-sheet';
 import { BwcProvider } from '../bwc/bwc';
+import { ConfigProvider } from '../config/config';
 import { Logger } from '../logger/logger';
+import { ProfileProvider } from '../profile/profile';
 import { IncomingDataProvider } from './incoming-data';
 
-describe('Provider: Incoming Data Provider', () => {
+fdescribe('Provider: Incoming Data Provider', () => {
   let incomingDataProvider: IncomingDataProvider;
   let bwcProvider: BwcProvider;
   let logger: Logger;
@@ -15,6 +17,8 @@ describe('Provider: Incoming Data Provider', () => {
   let loggerSpy;
   let eventsSpy;
   let actionSheetSpy;
+  let configProvider;
+  let profileProvider;
 
   class AppProviderMock {
     public info = {};
@@ -50,6 +54,20 @@ describe('Provider: Incoming Data Provider', () => {
     ).and.returnValue({
       present() {},
       onDidDismiss() {}
+    });
+    profileProvider = testBed.get(ProfileProvider);
+    spyOn(profileProvider, 'getWallets').and.returnValue([
+      {
+        credentials: {
+          keyId: 'keyId1'
+        }
+      }
+    ]);
+
+    configProvider = testBed.get(ConfigProvider);
+
+    spyOn(configProvider, 'get').and.returnValue({
+      allowMultiplePrimaryWallets: true
     });
   });
 

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -319,7 +319,7 @@ export class IncomingDataProvider {
   private goToImportByPrivateKey(data: string): void {
     this.logger.debug('Incoming-data (redirect): QR code export feature');
 
-    let stateParams = { code: data, fromScan: true };
+    let stateParams = { code: data };
     let nextView = {
       name: 'ImportWalletPage',
       params: stateParams
@@ -330,16 +330,16 @@ export class IncomingDataProvider {
   private goToJoinWallet(data: string): void {
     this.logger.debug('Incoming-data (redirect): Code to join to a wallet');
     if (this.isValidJoinCode(data)) {
-      let stateParams = { url: data, fromScan: true };
+      let stateParams = { url: data, isJoin: true };
       let nextView = {
-        name: 'JoinWalletPage',
+        name: 'AddWalletPage',
         params: stateParams
       };
       this.events.publish('IncomingDataRedir', nextView);
     } else if (this.isValidJoinLegacyCode(data)) {
-      let stateParams = { url: data, fromScan: true };
+      let stateParams = { url: data, isJoin: true };
       let nextView = {
-        name: 'JoinWalletPage',
+        name: 'AddWalletPage',
         params: stateParams
       };
       this.events.publish('IncomingDataRedir', nextView);

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -336,33 +336,30 @@ export class IncomingDataProvider {
     this.logger.debug('Incoming-data (redirect): Code to join to a wallet');
     let nextView, stateParams;
 
-    const opts2 = {
-      showHidden: true
+    const opts = {
+      showHidden: true,
+      canAddNewAccount: true
     };
-    const wallets2 = this.profileProvider.getWallets(opts2);
-    const nrKeys = _.values(_.groupBy(wallets2, 'keyId')).length;
+    const wallets = this.profileProvider.getWallets(opts);
+    const nrKeys = _.values(_.groupBy(wallets, 'keyId')).length;
     const config = this.configProvider.get();
     const allowMultiplePrimaryWallets =
       config.allowMultiplePrimaryWallets || nrKeys != 1;
 
-    const opts = {
-      canAddNewAccount: true
-    };
-    const wallets = this.profileProvider.getWallets(opts);
-    const walletsGroups: any[] = _.values(_.groupBy(wallets, 'keyId'));
-
-    if (
-      (allowMultiplePrimaryWallets && walletsGroups.length >= 1) ||
-      (!allowMultiplePrimaryWallets && walletsGroups.length > 1)
-    ) {
+    if (nrKeys === 0) {
+      stateParams = { url: data };
+      nextView = {
+        name: 'JoinWalletPage',
+        params: stateParams
+      };
+    } else if (allowMultiplePrimaryWallets) {
       stateParams = { url: data, isJoin: true };
       nextView = {
         name: 'AddWalletPage',
         params: stateParams
       };
-    } else if (!allowMultiplePrimaryWallets && walletsGroups.length === 1) {
-      const walletGroup = walletsGroups[0];
-      stateParams = { keyId: walletGroup[0].credentials.keyId, url: data };
+    } else if (!allowMultiplePrimaryWallets) {
+      stateParams = { keyId: wallets[0].credentials.keyId, url: data };
       nextView = {
         name: 'JoinWalletPage',
         params: stateParams


### PR DESCRIPTION
This PR fixes different cases when scan an invitation from general scanner:
1) If you have enabled `allowMultiplePrimaryWallets`, redirects to "add wallet page" before "join page", so you can choose between your different seeds or create a new one.
2) If you have disabled `allowMultiplePrimaryWallets`, redirects to "join page" directly and uses the same (and the only) seed that you have