### PR TITLE
Fix: switch in choose fee level page

### DIFF
--- a/src/pages/send/choose-fee-level/choose-fee-level.ts
+++ b/src/pages/send/choose-fee-level/choose-fee-level.ts
@@ -106,7 +106,7 @@ export class ChooseFeeLevelPage {
 
   private setFeeUnits() {
     const COIN = this.coin.toUpperCase();
-    switch (COIN) {
+    switch (this.coin) {
       case UTXO_COINS[COIN]:
         this.feeUnit = 'sat/byte';
         this.feeUnitAmount = 1000;


### PR DESCRIPTION
To prevent the switch from always going to default case