### PR TITLE
Use correct PayProUrl for ETH on invoice

### DIFF
--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -489,8 +489,8 @@ export class HomePage {
             this.payProDetailsData.amount = selectedTransactionCurrency
               ? paymentTotals[selectedTransactionCurrency]
               : Coin[currency]
-                ? price / 1e-8
-                : price;
+              ? price / 1e-8
+              : price;
             this.clearCountDownInterval();
             this.paymentTimeControl(expirationTime);
           } catch (err) {
@@ -611,9 +611,9 @@ export class HomePage {
 
     this.logger.debug(
       'fetching status for: ' +
-      opts.walletId +
-      ' alsohistory:' +
-      opts.alsoUpdateHistory
+        opts.walletId +
+        ' alsohistory:' +
+        opts.alsoUpdateHistory
     );
     const wallet = this.profileProvider.getWallet(opts.walletId);
     if (!wallet) return;

--- a/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
+++ b/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
@@ -9,6 +9,7 @@ import { FinishModalPage } from '../../../finish/finish';
 import { BitPayCardPage } from '../bitpay-card';
 
 // Provider
+import { IncomingDataProvider } from '../../../../providers';
 import { ActionSheetProvider } from '../../../../providers/action-sheet/action-sheet';
 import { BitPayCardProvider } from '../../../../providers/bitpay-card/bitpay-card';
 import { BitPayProvider } from '../../../../providers/bitpay/bitpay';
@@ -74,6 +75,7 @@ export class BitPayCardTopUpPage {
     private bwcProvider: BwcProvider,
     private configProvider: ConfigProvider,
     private externalLinkProvider: ExternalLinkProvider,
+    public incomingDataProvider: IncomingDataProvider,
     private logger: Logger,
     private modalCtrl: ModalController,
     private navCtrl: NavController,
@@ -277,10 +279,11 @@ export class BitPayCardTopUpPage {
   private createTx(wallet, invoice, message: string): Promise<any> {
     let COIN = wallet.coin.toUpperCase();
     return new Promise((resolve, reject) => {
-      let payProUrl =
-        invoice && invoice.paymentCodes
+      const paymentCode =
+        COIN !== 'ETH'
           ? invoice.paymentCodes[COIN].BIP73
-          : null;
+          : invoice.paymentCodes[COIN].EIP681;
+      const payProUrl = this.incomingDataProvider.getPayProUrl(paymentCode);
 
       if (!payProUrl) {
         return reject({

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -20,6 +20,7 @@ import { DecimalPipe } from '@angular/common';
 import {
   EmailNotificationsProvider,
   FeeProvider,
+  IncomingDataProvider,
   TxConfirmNotificationProvider,
   WalletTabsProvider
 } from '../../../../providers';
@@ -88,6 +89,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
     decimalPipe: DecimalPipe,
     feeProvider: FeeProvider,
     private giftCardProvider: GiftCardProvider,
+    public incomingDataProvider: IncomingDataProvider,
     keyProvider: KeyProvider,
     replaceParametersProvider: ReplaceParametersProvider,
     private emailNotificationsProvider: EmailNotificationsProvider,
@@ -298,8 +300,11 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
 
   private async createTx(wallet, invoice, message: string) {
     const COIN = wallet.coin.toUpperCase();
-    const payProUrl =
-      invoice && invoice.paymentCodes ? invoice.paymentCodes[COIN].BIP73 : null;
+    const paymentCode =
+      COIN !== 'ETH'
+        ? invoice.paymentCodes[COIN].BIP73
+        : invoice.paymentCodes[COIN].EIP681;
+    const payProUrl = this.incomingDataProvider.getPayProUrl(paymentCode);
 
     if (!payProUrl) {
       throw {

--- a/src/pages/integrations/invoice/confirm-invoice/confirm-invoice.ts
+++ b/src/pages/integrations/invoice/confirm-invoice/confirm-invoice.ts
@@ -15,6 +15,7 @@ import { Logger } from '../../../../providers/logger/logger';
 import { DecimalPipe } from '@angular/common';
 import {
   FeeProvider,
+  IncomingDataProvider,
   TxConfirmNotificationProvider,
   WalletTabsProvider
 } from '../../../../providers';
@@ -82,6 +83,7 @@ export class ConfirmInvoicePage extends ConfirmPage {
     configProvider: ConfigProvider,
     decimalPipe: DecimalPipe,
     feeProvider: FeeProvider,
+    public incomingDataProvider: IncomingDataProvider,
     private invoiceProvider: InvoiceProvider,
     replaceParametersProvider: ReplaceParametersProvider,
     externalLinkProvider: ExternalLinkProvider,
@@ -344,8 +346,11 @@ export class ConfirmInvoicePage extends ConfirmPage {
 
   public async createTx(wallet, invoice, message: string) {
     const COIN = wallet.coin.toUpperCase();
-    const payProUrl =
-      invoice && invoice.paymentCodes ? invoice.paymentCodes[COIN].BIP73 : null;
+    const paymentCode =
+      COIN !== 'ETH'
+        ? invoice.paymentCodes[COIN].BIP73
+        : invoice.paymentCodes[COIN].EIP681;
+    const payProUrl = this.incomingDataProvider.getPayProUrl(paymentCode);
 
     if (!payProUrl) {
       throw {

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -747,7 +747,7 @@ export class IncomingDataProvider {
     return coin;
   }
 
-  private getPayProUrl(data: string): string {
+  public getPayProUrl(data: string): string {
     return decodeURIComponent(
       data.replace(/(bitcoin|bitcoincash|ethereum)?:\?r=/, '')
     );


### PR DESCRIPTION
Payment Codes for ETH does not have BIP73 property, instead EIP681.

```
paymentCodes": {
"BTC": {
"BIP72b": "bitcoin:?r=https://test.bitpay.com/i/5d2KQ8rFWCHUnv6tQjmvcQ",
"BIP73": "https://test.bitpay.com/i/5d2KQ8rFWCHUnv6tQjmvcQ"
},
"BCH": {
"BIP72b": "bitcoincash:?r=https://test.bitpay.com/i/5d2KQ8rFWCHUnv6tQjmvcQ",
"BIP73": "https://test.bitpay.com/i/5d2KQ8rFWCHUnv6tQjmvcQ"
},
"ETH": {
"EIP681": "ethereum:?r=https://test.bitpay.com/i/5d2KQ8rFWCHUnv6tQjmvcQ"
}
},
```