### PR TITLE
Update BitPay Invoice URI flow

### DIFF
--- a/src/pages/integrations/invoice/confirm-invoice/confirm-invoice.html
+++ b/src/pages/integrations/invoice/confirm-invoice/confirm-invoice.html
@@ -2,18 +2,21 @@
   <ion-navbar>
     <ion-title>{{ 'Confirm' | translate }}</ion-title>
     <ion-buttons right>
-      <button (click)="openInBrowser()" tappable ion-button>
-        <img src="assets/img/paste-clipboard-light.svg" width="19" />
+      <button *ngIf="isCordova" (click)="openInBrowser()" ion-button>
+        {{ 'Copy' | translate }}
+      </button>
+      <button *ngIf="!isCordova" (click)="close()" ion-button>
+        {{ 'Cancel' | translate }}
       </button>
     </ion-buttons>
   </ion-navbar>
 </ion-header>
 
-<ion-content [ngClass]="{ 'no-margin-bottom': !isValidEmail() }">
+<ion-content>
   <ion-list>
     <ion-item>
       <div class="header-container">
-        <div class="gift-card-title">{{ invoiceName }}</div>
+        <div class="sending-label"><span translate>Sending</span></div>
         <div class="amount-label">
           <div class="amount">
             <div *ngIf="wallet">
@@ -23,7 +26,10 @@
             <div *ngIf="!wallet">
               {{ amount }} <span class="amount-coin">{{ currency }}</span>
             </div>
-            <img class="sending-img" src="assets/img/icon-tx-sent-outline.svg" />
+            <img
+              class="sending-img"
+              src="assets/img/icon-tx-sent-outline.svg"
+            />
           </div>
           <div *ngIf="totalAmount && !checkIfCoin()" class="alternative">
             <span *ngIf="onlyIntegers">
@@ -41,7 +47,11 @@
       </div>
     </ion-item>
 
-    <ion-item class="item-fee" [attr.detail-none]="usingMerchantFee ? '' : null" [ngClass]="{'btn-opacity': usingMerchantFee}">
+    <ion-item
+      class="item-fee"
+      [attr.detail-none]="usingMerchantFee ? '' : null"
+      [ngClass]="{ 'btn-opacity': usingMerchantFee }"
+    >
       <div class="fee-title">
         <span translate>This payment requires a miner fee of:</span> <br />
       </div>
@@ -75,55 +85,66 @@
         'Expired' | translate
       }}</ion-note>
     </ion-item>
-
     <button ion-item detail-none (click)="showWallets()" class="wallets-list">
       <div>{{ 'Sending From' | translate }}</div>
       <div class="wallet">
         <ion-icon *ngIf="wallet && wallet.coin" item-start>
-          <img [ngClass]="{ testnet: network === 'testnet' }" src="assets/img/currencies/{{wallet.coin}}.svg" class="icon-wallet" />
+          <img
+            [ngClass]="{ testnet: network === 'testnet' }"
+            src="assets/img/currencies/{{wallet.coin}}.svg"
+            class="icon-wallet"
+          />
         </ion-icon>
         <div>{{ wallet ? wallet.name : 'Select a wallet' }}</div>
         <div class="last-item" item-end>
           <button ion-button clear color="grey" icon-only>
-            <ion-icon *ngIf="!isOpenSelector" name="ios-arrow-down-outline"></ion-icon>
-            <ion-icon *ngIf="isOpenSelector" name="ios-arrow-up-outline"></ion-icon>
+            <ion-icon
+              *ngIf="!isOpenSelector"
+              name="ios-arrow-down-outline"
+            ></ion-icon>
+            <ion-icon
+              *ngIf="isOpenSelector"
+              name="ios-arrow-up-outline"
+            ></ion-icon>
           </button>
         </div>
       </div>
     </button>
 
-    <div>
-      <ion-item-divider>{{ 'Refund Email' | translate }}</ion-item-divider>
-      <ion-item>
-        <ion-input placeholder="{{'Enter an email address' | translate}}" [(ngModel)]="email" name="email" type="email" [disabled]="!!(this.buyerProvidedEmail || this.merchantProvidedEmail)">
-        </ion-input>
-      </ion-item>
-    </div>
-
-    <label-tip *ngIf="!isValidEmail()" type="danger">
-      <span label-tip-title translate><strong>A refund email is required.</strong></span>
-      <div label-tip-body translate>
-        If there is an issue with this payment, or a refund needs to be made, we will contact you at this address.<br />
-        <a (click)="openPrivacyPolicy()" translate>View Privacy Policy</a>
-      </div>
-    </label-tip>
-
-    <ion-item-divider></ion-item-divider>
+    <ion-item>
+      <ion-label stacked>{{ 'Memo' | translate }}</ion-label>
+      <ion-textarea
+        placeholder="{{'Enter a transaction memo' | translate}}"
+        [(ngModel)]="message"
+        name="message"
+        autocomplete="off"
+        autocorrect="off"
+      ></ion-textarea>
+    </ion-item>
   </ion-list>
 </ion-content>
 
 <ion-footer>
-  <page-slide-to-accept #slideButton *ngIf="isCordova" [disabled]="
-      !(wallet && totalAmountStr && isValidEmail() && !paymentExpired)
-    " buttonText="{{'Slide to confirm' | translate}}" (slideDone)="buyConfirm()" [ngClass]="{
-      'slide-confirm-fast slide-confirm-down':
-        hideSlideButton || !isValidEmail(),
-      'slide-confirm-slow': !hideSlideButton && isValidEmail()
-    }"></page-slide-to-accept>
+  <page-slide-to-accept
+    #slideButton
+    *ngIf="isCordova"
+    [disabled]="!(wallet && totalAmountStr)"
+    buttonText="{{'Slide to confirm' | translate}}"
+    (slideDone)="buyConfirm()"
+    [ngClass]="{
+      'slide-confirm-fast slide-confirm-down': hideSlideButton,
+      'slide-confirm-slow': !hideSlideButton
+    }"
+  >
+  </page-slide-to-accept>
   <ion-toolbar *ngIf="!isCordova">
-    <button ion-button full class="button-footer" (click)="buyConfirm()" [disabled]="
-        !(wallet && totalAmountStr && isValidEmail() && !paymentExpired)
-      ">
+    <button
+      ion-button
+      full
+      class="button-footer"
+      (click)="buyConfirm()"
+      [disabled]="!(wallet && totalAmountStr)"
+    >
       {{ 'Confirm
       purchase' | translate }}
     </button>

--- a/src/pages/integrations/invoice/confirm-invoice/confirm-invoice.scss
+++ b/src/pages/integrations/invoice/confirm-invoice/confirm-invoice.scss
@@ -75,45 +75,6 @@ confirm-invoice-page {
     border: none;
   }
 
-  .confirm-header {
-    padding-top: 25px;
-
-    ion-label {
-      display: flex;
-      align-items: center;
-    }
-
-    &__amount {
-      flex-grow: 1;
-    }
-
-    .card-list-item__icon {
-      img {
-        border: 1px #9ba3ae solid;
-        border-radius: 50%;
-        height: 45px;
-        margin-top: 35px;
-        width: 45px;
-      }
-    }
-  }
-
-  .gift-card-title {
-    display: flex;
-    align-items: center;
-    margin-bottom: 0.9rem;
-    margin-top: 0.9rem;
-    font-size: 20px;
-    font-weight: 500;
-
-    img {
-      width: 3.5rem;
-      margin-right: 1.5rem;
-      box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.3);
-      border-radius: $icon-border-radius;
-    }
-  }
-
   .amount-label {
     .amount {
       font-size: 38px;

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -204,23 +204,25 @@ export class IncomingDataProvider {
       ? Network.testnet
       : Network.livenet;
     this.invoiceProvider.setCredentials();
-    const invoiceResponse = await this.invoiceProvider
-      .getBitPayInvoiceData(invoiceId)
+    const invoice = await this.invoiceProvider
+      .getBitPayInvoice(invoiceId)
       .catch(err => {
-        throw this.logger.error(err);
+        return this.logger.error(err);
       });
-    const { invoice, org, buyer } = invoiceResponse;
-    const stateParams = {
-      invoiceData: invoice,
-      invoiceId,
-      invoiceName: org.name,
-      email: buyer ? buyer.email : null
-    };
-    let nextView = {
-      name: 'ConfirmInvoicePage',
-      params: stateParams
-    };
-    this.events.publish('IncomingDataRedir', nextView);
+    const { selectedTransactionCurrency } = invoice.buyerProvidedInfo;
+    if (selectedTransactionCurrency) {
+      this.goToPayPro(data, selectedTransactionCurrency.toLowerCase());
+    } else {
+      const stateParams = {
+        invoiceData: invoice,
+        invoiceId
+      };
+      let nextView = {
+        name: 'ConfirmInvoicePage',
+        params: stateParams
+      };
+      this.events.publish('IncomingDataRedir', nextView);
+    }
   }
 
   private handleBitcoinUri(data: string, redirParams?: RedirParams): void {

--- a/src/providers/invoice/invoice.ts
+++ b/src/providers/invoice/invoice.ts
@@ -51,64 +51,6 @@ export class InvoiceProvider {
     return res.data;
   }
 
-  public async getBitPayInvoiceData(id: string) {
-    const res: any = await this.http
-      .get(`${this.credentials.BITPAY_API_URL}/invoiceData/${id}`)
-      .toPromise()
-      .catch(err => {
-        this.logger.error('BitPay Get Invoice: ERROR ' + err.error.message);
-        throw err.error.message;
-      });
-    this.logger.info('BitPay Get Invoice: SUCCESS');
-    return res;
-  }
-
-  public async setBuyerProvidedCurrency(
-    buyerSelectedTransactionCurrency: string,
-    invoiceId: string
-  ) {
-    const req = {
-      buyerSelectedTransactionCurrency,
-      invoiceId
-    };
-    const res: any = await this.http
-      .post(
-        `${
-          this.credentials.BITPAY_API_URL
-        }/invoiceData/setBuyerSelectedTransactionCurrency`,
-        req
-      )
-      .toPromise()
-      .catch(err => {
-        this.logger.error('BitPay Invoice Set Currency: ERROR ' + err.error);
-        throw err.error;
-      });
-    this.logger.info('BitPay Invoice Set Currency: SUCCESS');
-    return res;
-  }
-
-  public async setBuyerProvidedEmail(
-    buyerProvidedEmail: string,
-    invoiceId: string
-  ) {
-    const req = {
-      buyerProvidedEmail,
-      invoiceId
-    };
-    const res: any = await this.http
-      .post(
-        `${this.credentials.BITPAY_API_URL}/invoiceData/setBuyerProvidedEmail`,
-        req
-      )
-      .toPromise()
-      .catch(err => {
-        this.logger.error('BitPay Invoice Set Email: ERROR ' + err.error);
-        throw err.error;
-      });
-    this.logger.info('BitPay Invoice Set Email: SUCCESS');
-    return res;
-  }
-
   public emailIsValid(email: string): boolean {
     const validEmail = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(
       email


### PR DESCRIPTION
- Deprecated`/invoiceData/` api route, does not provide `CORS` headers anymore, so we cannot use this route in Copay. Uses alternative `/invoices/` route.

The difference is `{ org, buyer }` is not returned from so we do not know if an email is set and we cannot set the `buyerProvidedEmail`. 

Also the merchant name is not known since `org` is not returned.

`confirm-invoice.ts`

- Removed `invoiceName`, anything related to `email`, `merchantEmail`, `buyerProvidedEmail`.

- Removed email field (will be replaced with BitPay ID soon).