### PR TITLE
Fix: "eth live card" improvements

### DIFF
--- a/src/pages/add-wallet/add-wallet.html
+++ b/src/pages/add-wallet/add-wallet.html
@@ -1,4 +1,4 @@
-<wide-header-page title="{{'Select Key' | translate}}">
+<wide-header-page title="{{ title }}">
   <div page-content>
     <ion-list class="settings-list bp-list">
       <button ion-item *ngFor="let walletsGroup of walletsGroups; let i = index" (click)="goToAddPage(walletsGroup[0].keyId)">

--- a/src/pages/add-wallet/add-wallet.ts
+++ b/src/pages/add-wallet/add-wallet.ts
@@ -1,7 +1,9 @@
 import { Component } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { NavController, NavParams } from 'ionic-angular';
 
 // pages
+import { CreateWalletPage } from '../add/create-wallet/create-wallet';
 import { JoinWalletPage } from '../add/join-wallet/join-wallet';
 import { SelectCurrencyPage } from '../add/select-currency/select-currency';
 
@@ -17,13 +19,20 @@ import * as _ from 'lodash';
 })
 export class AddWalletPage {
   public walletsGroups;
+  public fromEthCard: boolean;
+  public title: string;
 
   constructor(
     private navCtrl: NavController,
     private logger: Logger,
     private profileProvider: ProfileProvider,
-    private navParams: NavParams
+    private navParams: NavParams,
+    private translate: TranslateService
   ) {
+    this.fromEthCard = this.navParams.data.fromEthCard;
+    this.title = this.fromEthCard
+      ? this.translate.instant('Select Key to add ETH Wallet to')
+      : this.translate.instant('Select Key');
     const opts = {
       canAddNewAccount: true,
       showHidden: true
@@ -38,10 +47,18 @@ export class AddWalletPage {
 
   public goToAddPage(keyId): void {
     if (this.navParams.data.isCreate) {
-      this.navCtrl.push(SelectCurrencyPage, {
-        isShared: this.navParams.data.isShared,
-        keyId
-      });
+      if (this.fromEthCard) {
+        this.navCtrl.push(CreateWalletPage, {
+          isShared: false,
+          coin: 'eth',
+          keyId
+        });
+      } else {
+        this.navCtrl.push(SelectCurrencyPage, {
+          isShared: this.navParams.data.isShared,
+          keyId
+        });
+      }
     } else if (this.navParams.data.isJoin) {
       this.navCtrl.push(JoinWalletPage, {
         keyId,

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -79,7 +79,7 @@
 
     <page-feedback-card #showCard></page-feedback-card>
     <page-survey-card #showSurvey></page-survey-card>
-    <page-eth-live-card #showEthLiveCard (addEthClicked)="addWallet()"></page-eth-live-card>
+    <page-eth-live-card #showEthLiveCard (addEthClicked)="addWallet(true)"></page-eth-live-card>
 
     <div *ngIf="showPriceChart && wallets && wallets[0]">
       <div class="section-header" translate>Price Chart</div>

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -7,7 +7,9 @@ import * as moment from 'moment';
 import { Observable, Subscription } from 'rxjs';
 
 // Pages
+import { AddWalletPage } from '../add-wallet/add-wallet';
 import { AddPage } from '../add/add';
+import { CreateWalletPage } from '../add/create-wallet/create-wallet';
 import { BitPayCardPage } from '../integrations/bitpay-card/bitpay-card';
 import { BitPayCardIntroPage } from '../integrations/bitpay-card/bitpay-card-intro/bitpay-card-intro';
 import { CoinbasePage } from '../integrations/coinbase/coinbase';
@@ -874,7 +876,7 @@ export class HomePage {
     return this.collapsedGroups[keyId] ? true : false;
   }
 
-  public addWallet(): void {
+  public addWallet(fromEthCard?: boolean): void {
     let keyId;
     const compatibleKeyWallets = _.values(
       _.groupBy(
@@ -888,13 +890,27 @@ export class HomePage {
       )
     );
 
-    this.navCtrl.push(AddPage, {
-      // Select currency to add to the same key (1 single seed compatible key)
-      keyId: compatibleKeyWallets.length == 1 ? keyId : null,
-      // Creates new key (same flow as onboarding)
-      isZeroState: compatibleKeyWallets.length == 0 ? true : false,
-      // Select currency and Key or creates a new Key
-      isMultipleSeed: compatibleKeyWallets.length > 1 ? true : false
-    });
+    if (fromEthCard && compatibleKeyWallets.length == 1) {
+      this.navCtrl.push(CreateWalletPage, {
+        isShared: false,
+        coin: 'eth',
+        keyId
+      });
+    } else if (fromEthCard && compatibleKeyWallets.length > 1) {
+      this.navCtrl.push(AddWalletPage, {
+        isCreate: true,
+        isMultipleSeed: true,
+        fromEthCard
+      });
+    } else {
+      this.navCtrl.push(AddPage, {
+        // Select currency to add to the same key (1 single seed compatible key)
+        keyId: compatibleKeyWallets.length == 1 ? keyId : null,
+        // Creates new key (same flow as onboarding)
+        isZeroState: compatibleKeyWallets.length == 0 ? true : false,
+        // Select currency and Key or creates a new Key
+        isMultipleSeed: compatibleKeyWallets.length > 1 ? true : false
+      });
+    }
   }
 }

--- a/src/pages/includes/eth-live-card/eth-live-card.html
+++ b/src/pages/includes/eth-live-card/eth-live-card.html
@@ -10,7 +10,7 @@
     </div>
   </div>
   <div action-card-title>Start Using ETH Now</div>
-  <div action-card-body>Big news! Now you can use Ethereum in the BitPay App. Create your first ETH wallet today.</div>
+  <div action-card-body>Big news! Now you can use Ether (ETH) in the BitPay App. Create your first Ethereum wallet today.</div>
   <div action-card-button (click)="goToAddWalletFlow()" tappable>
     <span class="eth-live-btn">Add ETH Wallet</span>
   </div>

--- a/src/pages/includes/eth-live-card/eth-live-card.scss
+++ b/src/pages/includes/eth-live-card/eth-live-card.scss
@@ -8,7 +8,7 @@ page-eth-live-card {
     .eth-live-img {
       margin-bottom: 2rem;
       img {
-        margin-right: -22px;
+        margin-right: -12px;
       }
     }
     .action-card__content {


### PR DESCRIPTION
Improvements to the "Add eth wallet" flow:
- the user has only 1 single seed key now. In which case it can go ahead and add the eth wallet to that group.
- if the user has multiple single seed keys, it goes to the “select which key to add to” page, and creates an eth wallet there.

Correction in card texts
Fix to center the icon