### PR TITLE
chore(cordova-android): adds compatibility for android 6 or higher

### DIFF
--- a/app-template/config-template.xml
+++ b/app-template/config-template.xml
@@ -46,13 +46,17 @@
     <preference name="UseSwiftLanguageVersion" value="5" />
 
     <!-- Android Version: Pie 9.0 (API Level 28) or higher -->
-    <preference name="android-minSdkVersion" value="28" />
+    <!--<preference name="android-minSdkVersion" value="28" />-->
+
+    <!-- Android Version: Marshmallow 6.0 (API Level 23) or higher -->
+    <preference name="android-minSdkVersion" value="23" />
 
     <!-- iOS 10.3 or higher -->
     <preference name="deployment-target" value="10.3" />
 
     <!-- Supported Platforms -->
-    <engine name="android" spec="8.1.0" />
+    <!--<engine name="android" spec="8.1.0" />-->
+    <engine name="android" spec="7.1.4" />
     <engine name="ios" spec="5.0.1" />
 
     <!-- Plugins -->

--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -6,4 +6,4 @@ ext.postBuildExtras =
     compileSdkVersion 28
   }
 }
-ext.cdvMinSdkVersion = 28
+ext.cdvMinSdkVersion = 23

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "buffer-compare": "1.1.1",
     "chart.js": "2.8.0",
     "cordova": "8.1.2",
-    "cordova-android": "8.1.0",
+    "cordova-android": "7.1.4",
     "cordova-clipboard": "1.2.1",
     "cordova-custom-config": "https://github.com/cmgustavo/cordova-custom-config.git#3a1902fb700dc8c1e9ac9db592aa48d7d900cde0",
     "cordova-ios": "5.0.1",


### PR DESCRIPTION
Part of code has been commented to support Android 9 after 1st November.