### PR TITLE
Feat: QR code Key export

### DIFF
--- a/src/pages/add/import-wallet/import-wallet.ts
+++ b/src/pages/add/import-wallet/import-wallet.ts
@@ -186,12 +186,11 @@ export class ImportWalletPage {
       return undefined;
     }
     if (info.type == '1' && info.hasPassphrase) {
-      const title = this.translate.instant('Error');
+      const title = this.translate.instant('Warning');
       const subtitle = this.translate.instant(
         'Password required. Make sure to enter your password in advanced options'
       );
       this.popupProvider.ionicAlert(title, subtitle);
-      return undefined;
     }
     return info;
   }

--- a/src/pages/pages.ts
+++ b/src/pages/pages.ts
@@ -87,6 +87,7 @@ import { WalletGroupDeletePage } from '../pages/settings/wallet-group-settings/w
 import { WalletGroupExtendedPrivateKeyPage } from '../pages/settings/wallet-group-settings/wallet-group-extended-private-key/wallet-group-extended-private-key';
 import { WalletGroupNamePage } from '../pages/settings/wallet-group-settings/wallet-group-name/wallet-group-name';
 import { WalletGroupOnboardingPage } from '../pages/settings/wallet-group-settings/wallet-group-onboarding/wallet-group-onboarding';
+import { WalletGroupQrExportPage } from '../pages/settings/wallet-group-settings/wallet-group-qr-export/wallet-group-qr-export';
 import { WalletGroupSettingsPage } from '../pages/settings/wallet-group-settings/wallet-group-settings';
 
 /* Wallet Settings */
@@ -205,6 +206,7 @@ export const PAGES = [
   WalletDuplicatePage,
   WalletGroupExtendedPrivateKeyPage,
   WalletGroupDeletePage,
+  WalletGroupQrExportPage,
   WalletGroupSettingsPage,
   WalletGroupNamePage,
   WalletGroupOnboardingPage,

--- a/src/pages/settings/wallet-group-settings/wallet-group-qr-export/wallet-group-qr-export.html
+++ b/src/pages/settings/wallet-group-settings/wallet-group-qr-export/wallet-group-qr-export.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-navbar>
-    <ion-title>{{'QR Key Export' | translate}}</ion-title>
+    <ion-title>{{'Export key' | translate}}</ion-title>
   </ion-navbar>
 </ion-header>
 <ion-content>

--- a/src/pages/settings/wallet-group-settings/wallet-group-qr-export/wallet-group-qr-export.html
+++ b/src/pages/settings/wallet-group-settings/wallet-group-qr-export/wallet-group-qr-export.html
@@ -1,0 +1,22 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>{{'QR Key Export' | translate}}</ion-title>
+  </ion-navbar>
+</ion-header>
+<ion-content>
+  <div class="container">
+    <h3 translate>Warning!</h3>
+    <div class="warning-message">
+      <p translate>
+        Your Key is all that is needed to access your funds. Be sure to protect your key and store it only on secure devices. BitPay does not have access to your keys, so you alone are responsible for your keys. If you share key access with external services, you take responsibility for the risk of theft or breach.
+      </p>
+      <p>
+        {{ 'You can import this Key into other devices through the {appName} scanner' | translate: {appName: appName} }}
+      </p>
+    </div>
+    <div *ngIf="!keysEncrypted">
+      <ngx-qrcode *ngIf="code" hide-toast="true" qrc-value="{{code}}" qrc-class="aclass" qrc-errorCorrectionLevel="M"></ngx-qrcode>
+      <span *ngIf="walletsGroup && code">{{ walletsGroup.name }}</span>
+    </div>
+  </div>
+</ion-content>

--- a/src/pages/settings/wallet-group-settings/wallet-group-qr-export/wallet-group-qr-export.scss
+++ b/src/pages/settings/wallet-group-settings/wallet-group-qr-export/wallet-group-qr-export.scss
@@ -1,0 +1,12 @@
+page-wallet-group-qr-export {
+  .container {
+    h3 {
+      color: color($colors, danger);
+    }
+    text-align: center;
+    .warning-message {
+      line-height: 18px;
+      padding: 0 10px;
+    }
+  }
+}

--- a/src/pages/settings/wallet-group-settings/wallet-group-qr-export/wallet-group-qr-export.ts
+++ b/src/pages/settings/wallet-group-settings/wallet-group-qr-export/wallet-group-qr-export.ts
@@ -1,0 +1,97 @@
+import { Component } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { NavController, NavParams } from 'ionic-angular';
+
+// providers
+import { ActionSheetProvider } from '../../../../providers/action-sheet/action-sheet';
+import { AppProvider } from '../../../../providers/app/app';
+import { BwcErrorProvider } from '../../../../providers/bwc-error/bwc-error';
+import { KeyProvider } from '../../../../providers/key/key';
+import { Logger } from '../../../../providers/logger/logger';
+import { ProfileProvider } from '../../../../providers/profile/profile';
+
+@Component({
+  selector: 'page-wallet-group-qr-export',
+  templateUrl: 'wallet-group-qr-export.html'
+})
+export class WalletGroupQrExportPage {
+  public walletsGroup;
+  public keysEncrypted: boolean;
+  public code: string;
+  public appName: string;
+
+  private keyId;
+
+  constructor(
+    private profileProvider: ProfileProvider,
+    private logger: Logger,
+    private navParams: NavParams,
+    private navCtrl: NavController,
+    private actionSheetProvider: ActionSheetProvider,
+    private translate: TranslateService,
+    private bwcErrorProvider: BwcErrorProvider,
+    private keyProvider: KeyProvider,
+    private appProvider: AppProvider
+  ) {}
+
+  ionViewDidLoad() {
+    this.logger.info('Loaded: WalletQrExportPage');
+  }
+
+  ionViewWillEnter() {
+    this.keyId = this.navParams.data.keyId;
+    this.walletsGroup = this.profileProvider.getWalletGroup(this.keyId);
+    this.keysEncrypted = this.walletsGroup.isPrivKeyEncrypted;
+    this.appName = this.appProvider.info.nameCase;
+  }
+
+  ionViewDidEnter() {
+    this.keyProvider
+      .handleEncryptedWallet(this.keyId)
+      .then((password: string) => {
+        const keys = this.keyProvider.get(this.keyId, password);
+        this.keysEncrypted = false;
+        this.generateQrCode(keys);
+      })
+      .catch(err => {
+        if (err && err.message != 'PASSWORD_CANCELLED') {
+          let title = this.translate.instant('Could not decrypt wallet');
+          this.showErrorInfoSheet(this.bwcErrorProvider.msg(err), title);
+        }
+        this.navCtrl.pop();
+      });
+  }
+
+  public generateQrCode(keys) {
+    if (!keys || !keys.mnemonic) {
+      const err = this.translate.instant(
+        'Exporting via QR not supported for this wallet'
+      );
+      const title = this.translate.instant('Error');
+      this.showErrorInfoSheet(err, title);
+      return;
+    }
+
+    const mnemonicHasPassphrase = this.keyProvider.mnemonicHasPassphrase(
+      this.keyId
+    );
+    this.code =
+      '1|' + keys.mnemonic + '|null|null|' + mnemonicHasPassphrase + '|null';
+    this.logger.debug(
+      'QR code generated. mnemonicHasPassphrase: ' + mnemonicHasPassphrase
+    );
+  }
+
+  private showErrorInfoSheet(
+    err: Error | string,
+    infoSheetTitle: string
+  ): void {
+    if (!err) return;
+    this.logger.error('Could not get keys:', err);
+    const errorInfoSheet = this.actionSheetProvider.createInfoSheet(
+      'default-error',
+      { msg: err, title: infoSheetTitle }
+    );
+    errorInfoSheet.present();
+  }
+}

--- a/src/pages/settings/wallet-group-settings/wallet-group-settings.html
+++ b/src/pages/settings/wallet-group-settings/wallet-group-settings.html
@@ -116,7 +116,7 @@
       <ion-item-divider *ngIf="canSign">{{'Advanced' | translate}}</ion-item-divider>
 
       <button *ngIf="!needsBackup && canSign && !isDeletedSeed" ion-item (click)="openQrExport()">
-        <span translate>Export Key with QR</span>
+        <span translate>Export Key</span>
       </button>
 
       <button *ngIf="!needsBackup && canSign" ion-item (click)="openWalletGroupExtendedPrivateKey()">

--- a/src/pages/settings/wallet-group-settings/wallet-group-settings.html
+++ b/src/pages/settings/wallet-group-settings/wallet-group-settings.html
@@ -115,6 +115,10 @@
 
       <ion-item-divider *ngIf="canSign">{{'Advanced' | translate}}</ion-item-divider>
 
+      <button *ngIf="!needsBackup && canSign && !isDeletedSeed" ion-item (click)="openQrExport()">
+        <span translate>Export Key with QR</span>
+      </button>
+
       <button *ngIf="!needsBackup && canSign" ion-item (click)="openWalletGroupExtendedPrivateKey()">
         <span translate>Extended Private Key</span>
       </button>

--- a/src/pages/settings/wallet-group-settings/wallet-group-settings.ts
+++ b/src/pages/settings/wallet-group-settings/wallet-group-settings.ts
@@ -21,6 +21,7 @@ import { WalletSettingsPage } from '../wallet-settings/wallet-settings';
 import { WalletExportPage } from '../wallet-settings/wallet-settings-advanced/wallet-export/wallet-export';
 import { WalletGroupDeletePage } from './wallet-group-delete/wallet-group-delete';
 import { WalletGroupExtendedPrivateKeyPage } from './wallet-group-extended-private-key/wallet-group-extended-private-key';
+import { WalletGroupQrExportPage } from './wallet-group-qr-export/wallet-group-qr-export';
 
 @Component({
   selector: 'page-wallet-group-settings',
@@ -36,6 +37,7 @@ export class WalletGroupSettingsPage {
   public walletsGroup;
   public wallets;
   public canSign: boolean;
+  public isDeletedSeed: boolean;
   public needsBackup: boolean;
   public showReorder: boolean;
 
@@ -66,6 +68,7 @@ export class WalletGroupSettingsPage {
       showHidden: true
     });
     this.canSign = this.walletsGroup.canSign;
+    this.isDeletedSeed = this.walletsGroup.isDeletedSeed;
     this.needsBackup = this.walletsGroup.needsBackup;
     this.encryptEnabled = this.walletsGroup.isPrivKeyEncrypted;
   }
@@ -157,6 +160,12 @@ export class WalletGroupSettingsPage {
 
   public openWalletGroupDelete(): void {
     this.navCtrl.push(WalletGroupDeletePage, {
+      keyId: this.keyId
+    });
+  }
+
+  public openQrExport(): void {
+    this.navCtrl.push(WalletGroupQrExportPage, {
       keyId: this.keyId
     });
   }


### PR DESCRIPTION
1) The option to export the key as a QR code will appear in:
`Settings -> Key Settings -> Advanced -> Export Key with QR`
2) This option will only be seen if:
- The key backup is done
- The key has mnemonics
3) When scanning the QR, from the general scanner of the app -> It takes you to import and autocomplete the words
4) When scanning the QR from the import scanner -> that autocompletes the words

![Slack___Mustafa_Inamullah___BitPay](https://user-images.githubusercontent.com/10983458/67506538-998f2080-f663-11e9-934a-c4ccd48ee8eb.jpg)
