### PR TITLE
Fix: PayPro Provider unit tests

### DIFF
--- a/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
+++ b/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
@@ -357,6 +357,9 @@ export class BitPayCardTopUpPage {
             .catch(err => {
               return reject(err);
             });
+        })
+        .catch(err => {
+          return reject(err);
         });
     });
   }


### PR DESCRIPTION
The tests were obsolete causing many warnings

![MacBook-Pro____Documents_copay__zsh__y_BitPay_y_WhatsApp](https://user-images.githubusercontent.com/10983458/68128228-1472f980-fef6-11e9-9444-5330340d8080.jpg)
