### PR TITLE
Fix(fee) - Use chain for tx.feeStr and feeRatePerStr if Utxo

### DIFF
--- a/src/pages/includes/txp/txp.html
+++ b/src/pages/includes/txp/txp.html
@@ -25,7 +25,7 @@
     <div class="amount">
       <span *ngIf="tx.action == 'sent'">–</span>
       <span *ngIf="tx.action == 'invalid'" translate>(possible double spend)</span>
-      <span *ngIf="tx.action != 'invalid'">{{tx.amount | satToUnit: tx.coin}}</span>
+      <span *ngIf="tx.action != 'invalid'">{{tx.amountStr}}</span>
     </div>
     <div class="date">
       <time *ngIf="tx.createdOn && createdWithinPastDay(tx.createdOn * 1000)">{{tx.createdOn * 1000 | amTimeAgo}}</time>

--- a/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
+++ b/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
@@ -555,11 +555,13 @@ export class BitPayCardTopUpPage {
               ctxp.amount
             );
 
-            // Warn: fee too high
-            this.checkFeeHigh(
-              Number(parsedAmount.amountSat),
-              Number(invoiceFeeSat) + Number(ctxp.fee)
-            );
+            if (this.currencyProvider.isUtxoCoin(wallet.coin)) {
+              // Warn: fee too high
+              this.checkFeeHigh(
+                Number(parsedAmount.amountSat),
+                Number(invoiceFeeSat) + Number(ctxp.fee)
+              );
+            }
 
             this.setTotalAmount(
               wallet,

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -525,10 +525,12 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
     );
 
     // Warn: fee too high
-    this.checkFeeHigh(
-      Number(parsedAmount.amountSat),
-      Number(invoiceFeeSat) + Number(ctxp.fee)
-    );
+    if (this.currencyProvider.isUtxoCoin(wallet.coin)) {
+      this.checkFeeHigh(
+        Number(parsedAmount.amountSat),
+        Number(invoiceFeeSat) + Number(ctxp.fee)
+      );
+    }
 
     this.setTotalAmount(
       wallet,

--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -464,7 +464,12 @@ export class ConfirmPage extends WalletTabsChild {
                 tx.feeRate
               } vs. referent level (5 * feeRate) ${maxAllowedFee}`
             );
-            if (tx.network != 'testnet' && tx.feeRate > maxAllowedFee) {
+            const isUtxo = this.currencyProvider.isUtxoCoin(wallet.coin);
+            if (
+              tx.network != 'testnet' &&
+              tx.feeRate > maxAllowedFee &&
+              isUtxo
+            ) {
               this.onGoingProcessProvider.set('calculatingFee');
               this.showHighFeeSheet();
             }
@@ -573,9 +578,11 @@ export class ConfirmPage extends WalletTabsChild {
     return new Promise((resolve, reject) => {
       this.getTxp(_.clone(tx), wallet, opts.dryRun)
         .then(txp => {
-          const per = this.getFeeRate(txp.amount, txp.fee);
-          txp.feeRatePerStr = per.toFixed(2) + '%';
-          txp.feeTooHigh = this.isHighFee(txp.amount, txp.fee);
+          if (this.currencyProvider.isUtxoCoin(tx.coin)) {
+            const per = this.getFeeRate(txp.amount, txp.fee);
+            txp.feeRatePerStr = per.toFixed(2) + '%';
+            txp.feeTooHigh = this.isHighFee(txp.amount, txp.fee);
+          }
 
           if (txp.feeTooHigh) {
             this.showHighFeeSheet();

--- a/src/pages/txp-details/txp-details.html
+++ b/src/pages/txp-details/txp-details.html
@@ -21,8 +21,8 @@
         <div class="amount-label">
           <div class="amount">
             <div>
-              {{amount}}
-              <span class="amount-coin">{{tx.coin | uppercase}}</span>
+              {{tx.amountValueStr}}
+              <span class="amount-coin">{{tx.amountUnitStr | uppercase}}</span>
             </div>
             <img class="sending-img" src="assets/img/icon-tx-sent-outline.svg">
           </div>

--- a/src/pages/txp-details/txp-details.ts
+++ b/src/pages/txp-details/txp-details.ts
@@ -156,12 +156,17 @@ export class TxpDetailsPage {
   };
 
   private displayFeeValues(): void {
+    const chain = this.currencyProvider
+      .getChain(this.wallet.coin)
+      .toLowerCase();
     this.tx.feeFiatStr = this.txFormatProvider.formatAlternativeStr(
-      this.wallet.coin,
+      chain,
       this.tx.fee
     );
-    this.tx.feeRateStr =
-      ((this.tx.fee / (this.tx.amount + this.tx.fee)) * 100).toFixed(2) + '%';
+    if (this.currencyProvider.isUtxoCoin(this.wallet.coin)) {
+      this.tx.feeRateStr =
+        ((this.tx.fee / (this.tx.amount + this.tx.fee)) * 100).toFixed(2) + '%';
+    }
     const feeOpts = this.feeProvider.getFeeOpts();
     this.tx.feeLevelStr = feeOpts[this.tx.feeLevel];
   }

--- a/src/providers/tx-format/tx-format.ts
+++ b/src/providers/tx-format/tx-format.ts
@@ -138,10 +138,11 @@ export class TxFormatProvider {
     tx.amountStr = this.formatAmountStr(coin, tx.amount);
     tx.alternativeAmountStr = this.formatAlternativeStr(coin, tx.amount);
 
+    const chain = this.currencyProvider.getChain(coin).toLowerCase();
     tx.feeStr = tx.fee
-      ? this.formatAmountStr(coin, tx.fee)
+      ? this.formatAmountStr(chain, tx.fee)
       : tx.fees
-      ? this.formatAmountStr(coin, tx.fees)
+      ? this.formatAmountStr(chain, tx.fees)
       : 'N/A';
     if (tx.amountStr) {
       tx.amountValueStr = tx.amountStr.split(' ')[0];


### PR DESCRIPTION
All miner fees will be based on `chain` so:
- any ERC20 token will have fees in ETH.
- any SLP tokens will have fees in BCH.

Only if utxo based coin:
- `tx.feeRatePerStr`

Also fixes `txp-details.html` & `txp.html`
- Token txp.amount is `0` USDC. Uses `tx.amountStr` instead of `tx.amount` so it displays:

~~0.00 USDC~~ => `0.00 ETH`