### PR TITLE
Fix(card) - UI changes and remove buyerSelectedTransactionCurrency

### DIFF
--- a/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.html
+++ b/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.html
@@ -67,7 +67,7 @@
             <span *ngIf="!amount">...</span>
           </ion-note>
         </ion-item>
-        <ion-item>
+        <ion-item *ngIf="invoiceFee">
           <span class="item-info">{{'Network cost' | translate}}
             <ion-icon class="item-img" (click)="openExternalLink('networkCost')">
               <img src="assets/img/settings-icons/icon-help-support.svg" width="22">
@@ -90,8 +90,8 @@
         <ion-item>
           <span translate>Total</span>
           <ion-note item-end>
+            <span *ngIf="totalAmountStr">{{totalAmountStr}} ~ </span>
             <span *ngIf="totalAmount">{{totalAmount | number:'1.2-2'}} {{currencyIsoCode}}</span>
-            <span *ngIf="totalAmountStr">({{totalAmountStr}})</span>
           </ion-note>
         </ion-item>
       </div>

--- a/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
+++ b/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
@@ -450,8 +450,7 @@ export class BitPayCardTopUpPage {
 
             this.createInvoice({
               amount: maxAmount,
-              currency: wallet.coin.toUpperCase(),
-              buyerSelectedTransactionCurrency: wallet.coin.toUpperCase()
+              currency: wallet.coin.toUpperCase()
             })
               .then(inv => {
                 // Check if BTC or BCH is enabled in this account
@@ -517,8 +516,7 @@ export class BitPayCardTopUpPage {
     this.amountUnitStr = parsedAmount.amountUnitStr;
     var dataSrc = {
       amount: parsedAmount.amount,
-      currency: parsedAmount.currency,
-      buyerSelectedTransactionCurrency: wallet.coin.toUpperCase()
+      currency: parsedAmount.currency
     };
     this.onGoingProcessProvider.set('loadingTxInfo');
     this.createInvoice(dataSrc)


### PR DESCRIPTION
- PayProV2 - selectPaymentOptions sets the `buyerSelectedTransactionCurrency` now.
- Change UI to match `confirm-card-purchase.html`:
- Hides `Network cost` if `0`
- Total is now: ~~1 USD (0.12345 ETH)~~ => `0.12345 ETH ~ 1 USD`

<img width="359" alt="Screen Shot 2019-11-13 at 3 18 15 PM" src="https://user-images.githubusercontent.com/23103037/68800841-d4fc8980-0628-11ea-8714-89f6c96802f4.png">

