### PR TITLE
Hide token amount and only show USD total

### DIFF
--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.html
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.html
@@ -84,7 +84,7 @@
         <ion-item>
           <span>{{'Total' | translate}}</span>
           <ion-note item-end>
-            <span *ngIf="totalAmountStr">{{totalAmountStr}} ~ </span>
+            <span *ngIf="totalAmountStr && !isERCToken">{{totalAmountStr}} ~ </span>
             <span *ngIf="totalAmount">
               <span *ngIf="onlyIntegers">{{totalAmount | number : '1.0-0'}}</span>
               <span *ngIf="!onlyIntegers">{{totalAmount | number : '1.2-2'}}</span>

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -78,6 +78,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
   public amountUnitStr: string;
   public network: string;
   public onlyIntegers: boolean;
+  public isERCToken: boolean;
 
   public cardConfig: CardConfig;
   public hideSlideButton: boolean;
@@ -634,6 +635,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
 
   public onWalletSelect(wallet): void {
     this.wallet = wallet;
+    this.isERCToken = this.currencyProvider.isERCToken(this.wallet.coin);
     this.initialize(wallet).catch(() => {});
   }
 


### PR DESCRIPTION
For consistency between `bitpay-card-topup` page and `confirm-card-purchase` page