### PR TITLE
Fix responsiveness on camera scan detection for paypro

### DIFF
--- a/src/providers/incoming-data/incoming-data.spec.ts
+++ b/src/providers/incoming-data/incoming-data.spec.ts
@@ -276,10 +276,7 @@ describe('Provider: Incoming Data Provider', () => {
         getPayProOptionsSpy.and.returnValue(Promise.resolve(element));
 
         expect(incomingDataProvider.redir(element.payProUrl)).toBe(true);
-        expect(getPayProOptionsSpy).toHaveBeenCalledWith(
-          element.payProUrl,
-          true
-        );
+        expect(getPayProOptionsSpy).toHaveBeenCalledWith(element.payProUrl);
         expect(loggerSpy).toHaveBeenCalledWith(
           'Incoming-data: Handling bitpay invoice'
         );
@@ -389,10 +386,7 @@ describe('Provider: Incoming Data Provider', () => {
         getPayProOptionsSpy.and.returnValue(Promise.resolve(element));
 
         expect(incomingDataProvider.redir(element.payProUrl)).toBe(true);
-        expect(getPayProOptionsSpy).toHaveBeenCalledWith(
-          element.payProUrl,
-          true
-        );
+        expect(getPayProOptionsSpy).toHaveBeenCalledWith(element.payProUrl);
         expect(loggerSpy).toHaveBeenCalledWith(
           'Incoming-data: Handling bitpay invoice'
         );

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -210,10 +210,7 @@ export class IncomingDataProvider {
     this.logger.debug('Incoming-data: Handling bitpay invoice');
     try {
       const disableLoader = true;
-      const details = await this.payproProvider.getPayProOptions(
-        invoiceUrl,
-        disableLoader
-      );
+      const details = await this.payproProvider.getPayProOptions(invoiceUrl);
       const selected = details.paymentOptions.filter(option => option.selected);
       if (selected.length === 1) {
         // BTC, BCH, ETH Chains


### PR DESCRIPTION
How to test:

Scan a bitpay invoice QR code and check how long it takes to read the qr code on `master` vs `fix/disableLoader`