### PR TITLE
Implement activation fee 20 XRP ghost town UI

### DIFF
--- a/src/components/info-sheet/info-sheet.html
+++ b/src/components/info-sheet/info-sheet.html
@@ -25,7 +25,7 @@
       <span sheet-text *ngIf="params.coinName !== 'Ripple'">
         {{'Your wallet address is similar to a bank account number. You can add funds to your wallet by withdrawing funds you may have stored on an exchange to your wallet address. Or other {coinName} users can send you money by scanning your QR code.' | translate: {coinName: params.coinName} }}
       </span>
-      <span sheet-text *ngIf="params.coinName === 'Ripple'">The XRP ledger requires that all wallets maintain a minimum balance of 20 XRP. This 20 XRP will remain locked in your wallet, as the XRP ledger does not allow you to spend it.</span>
+      <span sheet-text *ngIf="params.coinName === 'Ripple'">The XRP ledger requires that all wallets maintain a minimum balance of 20 XRP. This non-refundable 20 XRP will remain permanently locked in your wallet.</span>
       <span sheet-text *ngIf="params.coinName === 'Ripple'"><strong><p>Please fund this address with 20 XRP to activate your wallet.</p></strong></span>
       <span sheet-button-text translate>GOT IT</span>
     </info-sheet-template>

--- a/src/pages/wallet-details/wallet-details.html
+++ b/src/pages/wallet-details/wallet-details.html
@@ -33,11 +33,22 @@
 
         <div (longPress)="toggleBalance()">
           <div (tap)="updateAll(true)" *ngIf="!wallet.balanceHidden && !wallet.scanning && !walletNotRegistered && (wallet.cachedStatus || wallet.lastKnownBalance)">
-            <div class="balance-str">
-              {{ wallet.cachedStatus ? wallet.cachedStatus.totalBalanceStr  : wallet.lastKnownBalance }} </div>
-            <div class="balance-alt-str" *ngIf="wallet.cachedStatus && wallet.cachedStatus.totalBalanceAlternative">
-              {{wallet.cachedStatus.totalBalanceAlternative}} {{wallet.cachedStatus.alternativeIsoCode}}
+            <div *ngIf="wallet.coin !== 'xrp'; else xrpBalance">
+              <div class="balance-str">
+                {{ wallet.cachedStatus ? wallet.cachedStatus.totalBalanceStr  : wallet.lastKnownBalance }} </div>
+              <div class="balance-alt-str" *ngIf="wallet.cachedStatus && wallet.cachedStatus.totalBalanceAlternative">
+                {{wallet.cachedStatus.totalBalanceAlternative}} {{wallet.cachedStatus.alternativeIsoCode}}
+              </div>
             </div>
+            <ng-template #xrpBalance>
+              <div (click)="openBalanceDetails()">
+                <div class="balance-str">
+                  {{ wallet.cachedStatus ? wallet.cachedStatus.availableBalanceStr  : wallet.lastKnownBalance }} </div>
+                <div class="balance-alt-str" *ngIf="wallet.cachedStatus && wallet.cachedStatus.totalBalanceAlternative">
+                  {{wallet.cachedStatus.availableBalanceAlternative}} {{wallet.cachedStatus.alternativeIsoCode}}
+                </div>
+              </div>
+            </ng-template>
             <div class="balance-alt-str" *ngIf="!wallet.scanning && !wallet.cachedStatus && wallet.lastKnownBalanceUpdatedOn">
               {{ wallet.lastKnownBalanceUpdatedOn * 1000 | amTimeAgo }}
             </div>
@@ -97,7 +108,7 @@
           <span class="token" *ngIf="wallet.linkedEthWalletName">
             <span>{{'Linked to wallet: {linkedEthWalletName}' | translate : {linkedEthWalletName: wallet.linkedEthWalletName} }}</span>
           </span>
-          <span class="token" *ngIf="wallet.coin === 'xrp' && history && history[0]">
+          <span class="token" *ngIf="wallet.coin === 'xrp' && wallet.cachedStatus && wallet.cachedStatus.lockedBalanceSat">
             <span translate>Activated</span>
           </span>
           <span class="wallet-type" *ngIf="wallet.credentials.n > 1">
@@ -151,12 +162,20 @@
             <img src="assets/img/ghost-tongue-out.svg" />
           </div>
           <div class="title-info">
-            <span translate>It's a ghost town in here</span>
+            <span translate *ngIf="wallet.coin === 'xrp' && wallet.cachedStatus && !wallet.cachedStatus.lockedBalanceSat; else ghostTown">20 XRP required to activate</span>
+            <ng-template #ghostTown>
+              <span translate>It's a ghost town in here</span>
+            </ng-template>
           </div>
           <div class="subtitle-info">
-            <span translate>
-              If you have funds stored on a website then you should move them into a secure wallet... like this one!
+            <span translate *ngIf="wallet.coin === 'xrp' && wallet.cachedStatus && !wallet.cachedStatus.lockedBalanceSat; else noFunds">
+              The XRP ledger requires that all wallets maintain a minimum balance of 20 XRP. This non-refundable 20 XRP will remain permanently locked in your wallet.
             </span>
+            <ng-template #noFunds>
+              <span translate>
+                If you have funds stored on a website then you should move them into a secure wallet... like this one!
+              </span>
+            </ng-template>
           </div>
         </div>
 

--- a/src/pages/wallet-details/wallet-details.ts
+++ b/src/pages/wallet-details/wallet-details.ts
@@ -326,6 +326,13 @@ export class WalletDetailsPage extends WalletTabsChild {
       this.setPendingTxps(status.pendingTxps);
       this.showBalanceButton = status.totalBalanceSat != status.spendableAmount;
 
+      const minXrpBalance = 20000000; // 20 XRP * 1e6
+      if (this.wallet.coin === 'xrp') {
+        this.showBalanceButton =
+          status.totalBalanceSat &&
+          status.totalBalanceSat != status.spendableAmount + minXrpBalance;
+      }
+
       if (this.isUtxoCoin()) {
         this.analyzeUtxos();
       }


### PR DESCRIPTION
relies on:

https://github.com/bitpay/bitcore/pull/2665

Changes:

Can click on balance to show total balance, available, confirming, and locked:

<img width="288" alt="Screen Shot 2020-01-09 at 3 37 02 PM" src="https://user-images.githubusercontent.com/23103037/72102841-e646d700-32f5-11ea-9f74-083c92d79448.png">

New Wallet State:

<img width="288" alt="Screen Shot 2020-01-09 at 3 36 17 PM" src="https://user-images.githubusercontent.com/23103037/72102793-d0391680-32f5-11ea-9061-efcfb4448015.png">

Activated Wallet with total balance of 20 XRP:

<img width="289" alt="Screen Shot 2020-01-09 at 3 40 48 PM" src="https://user-images.githubusercontent.com/23103037/72103089-78e77600-32f6-11ea-8471-daf36ec3605e.png">
