### PR TITLE
Refactor XRP paymentCode to BIP73

### DIFF
--- a/src/providers/currency/coin.ts
+++ b/src/providers/currency/coin.ts
@@ -166,7 +166,7 @@ export const availableCoins: CoinsMap<CoinOpts> = {
       singleAddress: true
     },
     paymentInfo: {
-      paymentCode: 'RIP681',
+      paymentCode: 'BIP73',
       protocolPrefix: { livenet: 'ripple', testnet: 'ripple' },
       ratesApi: 'https://bitpay.com/api/rates/xrp',
       blockExplorerUrls: 'xrpscan.com/'


### PR DESCRIPTION
Not urgent, but a refactor to clean up paymentCodes from bitpay invoice response

```
"paymentCodes": {
    "XRP": {
      "BIP72b": "ripple:?r=https://staging.bitpay.com/i/5bYo33pPKhKPZb8uf1xKLU",
      "BIP73": "https://staging.bitpay.com/i/5bYo33pPKhKPZb8uf1xKLU",
      "RIP681": "https://staging.bitpay.com/i/5bYo33pPKhKPZb8uf1xKLU"
     }
```

~~"RIP681": "https://staging.bitpay.com/i/5bYo33pPKhKPZb8uf1xKLU"~~