### PR TITLE
P2P: Understand bitpay://invoice?url=

### DIFF
--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -181,6 +181,13 @@ export class IncomingDataProvider {
     );
   }
 
+  private isValidInvoiceUri(data: string): boolean {
+    data = this.sanitizeUri(data);
+    return !!(
+      data && data.indexOf(this.appProvider.info.name + '://invoice') === 0
+    );
+  }
+
   private isValidBitPayCardUri(data: string): boolean {
     data = this.sanitizeUri(data);
     return !!(data && data.indexOf('bitpay://bitpay') === 0);
@@ -601,6 +608,13 @@ export class IncomingDataProvider {
     this.incomingDataRedir(nextView);
   }
 
+  private goToInvoice(data: string): void {
+    this.logger.debug('Incoming-data (redirect): Invoice URL');
+
+    const invoiceUrl = this.getParameterByName('url', data);
+    this.redir(invoiceUrl);
+  }
+
   public redir(data: string, redirParams?: RedirParams): boolean {
     if (redirParams && redirParams.activePage)
       this.activePage = redirParams.activePage;
@@ -678,6 +692,11 @@ export class IncomingDataProvider {
       // Simplex
     } else if (this.isValidSimplexUri(data)) {
       this.goToSimplex(data);
+      return true;
+
+      // Invoice Intent
+    } else if (this.isValidInvoiceUri(data)) {
+      this.goToInvoice(data);
       return true;
 
       // BitPayCard Authentication


### PR DESCRIPTION
Required for p2p wallet selector invoice redesign.

Main feature is for iOS to open up specifically Bitpay/Copay wallet.

Bitpay Wallet:
`bitpay://invoice?url=`

Copay Wallet:
`copay://invoice?url=`