### PR TITLE
forwarding events back to ref with subject

### DIFF
--- a/src/models/in-app-browser/in-app-browser-ref.model.ts
+++ b/src/models/in-app-browser/in-app-browser-ref.model.ts
@@ -1,7 +1,7 @@
 /// <reference types="cordova-plugin-inappbrowser" />
 
-import { Observable } from 'rxjs';
+import { Subject } from 'rxjs';
 export interface InAppBrowserRef extends InAppBrowser {
-  events$?: Observable<Event>;
+  events$?: Subject<Event>;
   error?: boolean;
 }

--- a/src/providers/external-link/external-link.ts
+++ b/src/providers/external-link/external-link.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 import { Logger } from '../../providers/logger/logger';
 
 // providers
+import { Events } from 'ionic-angular';
+import { Observable } from 'rxjs/Observable';
 import { ElectronProvider } from '../electron/electron';
 import { PlatformProvider } from '../platform/platform';
 import { PopupProvider } from '../popup/popup';
@@ -12,7 +14,8 @@ export class ExternalLinkProvider {
     private popupProvider: PopupProvider,
     private logger: Logger,
     private platformProvider: PlatformProvider,
-    private electronProvider: ElectronProvider
+    private electronProvider: ElectronProvider,
+    private events: Events
   ) {
     this.logger.debug('ExternalLinkProvider initialized');
   }
@@ -54,10 +57,17 @@ export class ExternalLinkProvider {
       this.logger.debug('Skip: ' + url);
     };
 
-    if (res)
-      this.platformProvider.isElectron
-        ? this.electronProvider.openExternalLink(url)
-        : window.open(url, '_system');
+    if (res) {
+      if (this.platformProvider.isElectron) {
+        this.electronProvider.openExternalLink(url);
+      } else {
+        // workaround for an existing cordova inappbrowser plugin issue - redirecting events back to the iab ref
+        const w = window.open(url, '_system');
+        Observable.fromEvent(w, 'message').subscribe(e =>
+          this.events.publish('iab_message_update', e)
+        );
+      }
+    }
 
     this.restoreHandleOpenURL(old);
   }

--- a/src/providers/in-app-browser/in-app-browser.ts
+++ b/src/providers/in-app-browser/in-app-browser.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { Observable } from 'rxjs';
+import { Events } from 'ionic-angular';
+import { Subject } from 'rxjs/Subject';
 import { InAppBrowserRef } from '../../models/in-app-browser/in-app-browser-ref.model';
 import { ActionSheetProvider } from '../../providers/action-sheet/action-sheet';
 import { Logger } from '../../providers/logger/logger';
@@ -15,7 +16,8 @@ export class InAppBrowserProvider {
   constructor(
     private logger: Logger,
     private actionSheetProvider: ActionSheetProvider,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private events: Events
   ) {
     this.logger.debug('InAppBrowserProvider initialized');
   }
@@ -73,9 +75,10 @@ export class InAppBrowserProvider {
         rej();
       });
 
-      // add observable to listen for url changes
-      ref.events$ = Observable.fromEvent(ref, 'message');
+      ref.events$ = new Subject<Event>();
 
+      ref.addEventListener('message', e => ref.events$.next(e));
+      this.events.subscribe('iab_message_update', e => ref.events$.next(e));
       // providing two ways to get ref - caching it here and also returning it
       this.refs[refName] = ref;
 


### PR DESCRIPTION
This PR is a workaround for a known cordova inappbrowser plugin issue where events are not sent to the correct window. 