### PR TITLE
getHistoricalRates returns CoinsMap<ApiPrice[]>

### DIFF
--- a/src/components/exchange-rates/exchange-rates.ts
+++ b/src/components/exchange-rates/exchange-rates.ts
@@ -60,19 +60,17 @@ export class ExchangeRates {
 
   public getPrices() {
     this.setIsoCode();
-    _.forEach(this.coins, (coin, index) => {
-      this.exchangeRatesProvider
-        .getHistoricalRates(this.isoCode, coin.unitCode)
-        .subscribe(
-          response => {
-            this.coins[index].historicalRates = response.reverse();
-            this.updateValues(index);
-          },
-          err => {
-            this.logger.error('Error getting rates:', err);
-          }
-        );
-    });
+    this.exchangeRatesProvider.getHistoricalRates(this.isoCode).subscribe(
+      response => {
+        _.forEach(this.coins, (coin, index) => {
+          this.coins[index].historicalRates = response[coin.unitCode].reverse();
+          this.updateValues(index);
+        });
+      },
+      err => {
+        this.logger.error('Error getting rates:', err);
+      }
+    );
   }
 
   public updateCurrentPrice() {

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -389,33 +389,22 @@ export class HomePage {
 
   private getLastDayRates(): Promise<any> {
     const availableChains = this.currencyProvider.getAvailableChains();
-    const getHistoricalRate = unitCode => {
-      return new Promise(resolve => {
-        this.exchangeRatesProvider
-          .getHistoricalRates(this.totalBalanceAlternativeIsoCode, unitCode)
-          .subscribe(
-            response => {
-              const lastDayRate = response.reverse()[0];
-              return resolve({ rate: lastDayRate, unitCode });
-            },
-            err => {
-              this.logger.error('Error getting current rate:', err);
-              return resolve();
+    return new Promise(resolve => {
+      this.exchangeRatesProvider
+        .getHistoricalRates(this.totalBalanceAlternativeIsoCode)
+        .subscribe(
+          response => {
+            let ratesByCoin = {};
+            for (const unitCode of availableChains) {
+              ratesByCoin[unitCode] = response[unitCode][0].rate;
             }
-          );
-      });
-    };
-
-    const promises = [];
-    _.forEach(availableChains, unitCode => {
-      promises.push(getHistoricalRate(unitCode));
-    });
-    return Promise.all(promises).then(lastDayRates => {
-      let ratesByCoin = {};
-      lastDayRates.forEach(lastDayRate => {
-        ratesByCoin[lastDayRate.unitCode] = lastDayRate.rate.rate;
-      });
-      return Promise.resolve(ratesByCoin);
+            return resolve(ratesByCoin);
+          },
+          err => {
+            this.logger.error('Error getting current rate:', err);
+            return resolve();
+          }
+        );
     });
   }
 


### PR DESCRIPTION
https://github.com/bitpay/bitcore/pull/2747

### No caching - 2 API calls

1. getLastDayRates() `home.ts`
2. getPrices() `exchange-rates.ts`

<img width="910" alt="Screen Shot 2020-03-05 at 3 09 21 PM" src="https://user-images.githubusercontent.com/23103037/76021441-512a1e00-5ef3-11ea-8bae-12049e4cb6fd.png">

### Rates Caching - 1 API call only

<img width="801" alt="Screen Shot 2020-03-06 at 11 20 19 AM" src="https://user-images.githubusercontent.com/23103037/76101657-c69df900-5f9c-11ea-8d04-24b51206279d.png">
