### PR TITLE
added optional code; added error handling if failed pairing

### DIFF
--- a/src/models/user/user.model.ts
+++ b/src/models/user/user.model.ts
@@ -5,4 +5,5 @@ export interface User {
     email?: string;
     eid?: string;
   };
+  error?: string;
 }

--- a/src/providers/bitpay-id/bitpay-id.ts
+++ b/src/providers/bitpay-id/bitpay-id.ts
@@ -113,7 +113,6 @@ export class BitPayIdProvider {
               .toPromise();
 
             if (user) {
-
               if (user.error) {
                 errorCallback(user.error);
                 return;

--- a/src/providers/bitpay-id/bitpay-id.ts
+++ b/src/providers/bitpay-id/bitpay-id.ts
@@ -42,7 +42,7 @@ export class BitPayIdProvider {
     };
   }
 
-  public generatePairingToken(secret, successCallback, errorCallback) {
+  public generatePairingToken(payload, successCallback, errorCallback) {
     const network = Network[this.getEnvironment().network];
 
     this.appIdentityProvider.getIdentity(network, (err, appIdentity) => {
@@ -51,13 +51,21 @@ export class BitPayIdProvider {
         return errorCallback(err);
       }
 
+      const { secret, code } = payload;
+
+      const params = {
+        secret,
+        version: 2,
+        deviceName: this.deviceName
+      };
+
+      if (code) {
+        params['code'] = code;
+      }
+
       let json: any = {
         method: 'createToken',
-        params: {
-          secret,
-          version: 2,
-          deviceName: this.deviceName
-        }
+        params
       };
 
       let dataToSign = JSON.stringify(json['params']);
@@ -88,8 +96,6 @@ export class BitPayIdProvider {
               .post(url, json, { headers })
               .toPromise();
 
-            this.logger.debug('BitPayID: successfully paired');
-
             json = {
               method: 'getBasicInfo',
               token: token.data
@@ -107,6 +113,13 @@ export class BitPayIdProvider {
               .toPromise();
 
             if (user) {
+
+              if (user.error) {
+                errorCallback(user.error);
+                return;
+              }
+
+              this.logger.debug('BitPayID: successfully paired');
               const { data } = user;
               // const { email, familyName, givenName } = data;
 

--- a/src/providers/in-app-browser/card.ts
+++ b/src/providers/in-app-browser/card.ts
@@ -207,17 +207,26 @@ export class IABCardProvider {
          * */
 
         case 'pairing':
-          const { secret } = event.data.params;
           // generates pairing token and also fetches user basic info and caches both
           this.bitpayIdProvider.generatePairingToken(
-            secret,
+            event.data.params,
             (user: User) => {
               if (user) {
                 this.getCards();
                 this.user.next(user);
               }
             },
-            err => this.logger.debug(err)
+            () => {
+              this.cardIAB_Ref.hide();
+              const errorSheet = this.actionSheetProvider.createInfoSheet(
+                'default-error',
+                {
+                  title: 'BitPay ID',
+                  msg: 'Uh oh, something went wrong please try again later.'
+                }
+              );
+              errorSheet.present();
+            }
           );
           break;
 

--- a/src/providers/in-app-browser/card.ts
+++ b/src/providers/in-app-browser/card.ts
@@ -216,7 +216,9 @@ export class IABCardProvider {
                 this.user.next(user);
               }
             },
-            () => {
+            error => {
+              this.logger.error(`pairing error -> ${error}`);
+
               this.cardIAB_Ref.hide();
               const errorSheet = this.actionSheetProvider.createInfoSheet(
                 'default-error',


### PR DESCRIPTION
This PR adds an optional 2fa code if present and also handles failed pairings more gracefully by closing the IAB and showing an error-default bottom sheet.