### PR TITLE
Bump v9.3.1-beta

### DIFF
--- a/app-template/bitpay/appConfig.json
+++ b/app-template/bitpay/appConfig.json
@@ -24,8 +24,8 @@
   "WindowsApplicationId": "BitPayforWindows",
   "pushSenderId": "1036948132229",
   "description": "Secure Bitcoin Wallet",
-  "version": "9.3.0",
-  "androidVersion": "90030000",
+  "version": "9.3.1",
+  "androidVersion": "90030100",
   "_extraCSS": null,
   "_enabledExtensions": {
     "coinbase": true,

--- a/app-template/copay/appConfig.json
+++ b/app-template/copay/appConfig.json
@@ -24,8 +24,8 @@
   "WindowsApplicationId": "CopayforWindows",
   "pushSenderId": "1036948132229",
   "description": "A Secure Bitcoin Wallet",
-  "version": "9.3.0",
-  "androidVersion": "90030000",
+  "version": "9.3.1",
+  "androidVersion": "90030100",
   "_extraCSS": null,
   "_enabledExtensions": {
     "coinbase": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "copay",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "copay",
   "description": "A Secure Bitcoin Wallet",
   "author": "BitPay",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "keywords": [
     "bitcoin",
     "wallet",


### PR DESCRIPTION
* [FEAT] choose inputs for transaction (#10755)
* Fix: balance to show undefined in wallet details (#10763)
* [FEAT] add consolidated cards (#10762)
  * added new logos
  * consolidating galileo cards
  * updated card fetch to use graph
  * caching card data in iab session storage
  * added ability to designate network when enabling card experiment
  * tied updateBalance back from iab to wallet
  * added slight animation to help smooth out tile/card updates