### PR TITLE
fix(safe-area): adds padding bottom for iPhoneX

### DIFF
--- a/src/pages/settings/about/session-log/session-log.scss
+++ b/src/pages/settings/about/session-log/session-log.scss
@@ -14,7 +14,7 @@ page-session-log {
     font-weight: bold;
   }
   .filter-container {
-    padding: 20px;
+    padding: 0 20px;
     .labels {
       color: black;
       display: flex;

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -199,13 +199,12 @@ ion-footer {
   }
 }
 
-/* Force safe-area for iPhone X -- Need testing
-.ios .tabs:not(.tabs-ios[tabsPlacement=top]) ion-footer .toolbar:last-child {
+/* Force safe-area for iPhone X with ion-footer */
+.ios .tabs:not(.tabs-ios[tabsPlacement='top']) ion-footer .toolbar:last-child {
   padding-bottom: 0 !important;
   padding-bottom: calc(env(safe-area-inset-bottom)) !important;
   padding-bottom: -webkit-calc(env(safe-area-inset-bottom)) !important;
 }
-*/
 
 .toolbar {
   // Titles centered on all headers for material design


### PR DESCRIPTION
This PR adds safe-bottom-area for iPhoneX in some views that contains `ion-footer` like shapeshift, buy-gift-card, session-log, etc.