### PR TITLE
fix wrong payment code for BUSD

### DIFF
--- a/src/providers/currency/coin.ts
+++ b/src/providers/currency/coin.ts
@@ -196,12 +196,12 @@ export const availableCoins: CoinsMap<CoinOpts> = {
       hasMultiSig: false,
       hasMultiSend: false,
       isUtxo: false,
-      isERCToken: false,
-      isStableCoin: false,
+      isERCToken: true,
+      isStableCoin: true,
       singleAddress: true
     },
     paymentInfo: {
-      paymentCode: 'EIP681',
+      paymentCode: 'EIP681b',
       protocolPrefix: { livenet: 'ethereum', testnet: 'ethereum' },
       ratesApi: 'https://bitpay.com/api/rates/busd',
       blockExplorerUrls: 'bitpay.com/insight/#/ETH/'


### PR DESCRIPTION
```
"paymentCodes": {
    "BUSD": {
        "EIP681b": "ethereum:?r=https://test.bitpay.com/i/KZnEvLXtaL9e5yQpL5APRx"
     },
```
**confirm-card-purchase.ts** LN349:

```
    const paymentCode = this.currencyProvider.getPaymentCode(wallet.coin);
    const protocolUrl = invoice.paymentCodes[COIN][paymentCode];
    const payProUrl = this.incomingDataProvider.getPayProUrl(protocolUrl);
```

**incoming-data.ts** LN1034

```
public getPayProUrl(data: string): string {
    return decodeURIComponent(
      data.replace(/(bitcoin|bitcoincash|ethereum|ripple)?:\?r=/, '')
    );
  }
```

data is undefined as protocolUrl is undefined.

Error:

![image](https://user-images.githubusercontent.com/23103037/81123373-ea2fe200-8f00-11ea-9d49-5e659f20f3cb.png)

![image](https://user-images.githubusercontent.com/23103037/81123631-8b1e9d00-8f01-11ea-9df5-e5baf6c0ad29.png)
