### PR TITLE
Fix: default values when comes from charts

### DIFF
--- a/src/pages/integrations/simplex/simplex-buy/simplex-buy.ts
+++ b/src/pages/integrations/simplex/simplex-buy/simplex-buy.ts
@@ -294,6 +294,9 @@ export class SimplexBuyPage {
     );
     if (!this.wallet) return;
 
+    // To take default values after switching between currencies coming from charts
+    this.amount = undefined;
+
     if (this.currencyIsFiat()) {
       this.setFiatValues();
     } else {


### PR DESCRIPTION
Bug fixed: If you go to Simplex through charts and then change the selected currency, default values are not updated