### PR TITLE
Feat(PayPro) - Add address param to getPaymentDetails

### DIFF
--- a/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
+++ b/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
@@ -320,94 +320,100 @@ export class BitPayCardTopUpPage {
         });
       }
 
-      this.payproProvider
-        .getPayProDetails(payProUrl, wallet.coin)
-        .then(details => {
-          const { instructions } = details;
+      this.walletProvider
+        .getAddress(wallet, false)
+        .then(address => {
+          this.payproProvider
+            .getPayProDetails({
+              paymentUrl: payProUrl,
+              coin: wallet.coin,
+              address
+            })
+            .then(details => {
+              const { instructions } = details;
 
-          this.logger.debug(
-            `PayProDetails instructions amount ${_.sumBy(
-              instructions,
-              'amount'
-            )}`
-          );
-          let txp: Partial<TransactionProposal> = {
-            coin: wallet.coin,
-            amount: _.sumBy(instructions, 'amount'),
-            toAddress: instructions[0].toAddress,
-            outputs: [],
-            message,
-            customData: {
-              service: 'debitcard'
-            },
-            payProUrl,
-            excludeUnconfirmedUtxos: this.configWallet.spendUnconfirmed
-              ? false
-              : true
-          };
+              this.logger.debug(
+                `PayProDetails instructions amount ${_.sumBy(
+                  instructions,
+                  'amount'
+                )}`
+              );
+              let txp: Partial<TransactionProposal> = {
+                coin: wallet.coin,
+                amount: _.sumBy(instructions, 'amount'),
+                from: address,
+                toAddress: instructions[0].toAddress,
+                outputs: [],
+                message,
+                customData: {
+                  service: 'debitcard'
+                },
+                payProUrl,
+                excludeUnconfirmedUtxos: this.configWallet.spendUnconfirmed
+                  ? false
+                  : true
+              };
 
-          for (const instruction of instructions) {
-            txp.outputs.push({
-              toAddress: instruction.toAddress,
-              amount: instruction.amount,
-              message: instruction.message,
-              data: instruction.data
-            });
-          }
+              for (const instruction of instructions) {
+                txp.outputs.push({
+                  toAddress: instruction.toAddress,
+                  amount: instruction.amount,
+                  message: instruction.message,
+                  data: instruction.data
+                });
+              }
 
-          if (
-            wallet.coin === 'xrp' &&
-            instructions &&
-            instructions[0] &&
-            instructions[0].outputs &&
-            instructions[0].outputs[0] &&
-            instructions[0].outputs[0].invoiceID
-          ) {
-            txp.invoiceID = instructions[0].outputs[0].invoiceID;
-          }
+              if (
+                wallet.coin === 'xrp' &&
+                instructions &&
+                instructions[0] &&
+                instructions[0].outputs &&
+                instructions[0].outputs[0] &&
+                instructions[0].outputs[0].invoiceID
+              ) {
+                txp.invoiceID = instructions[0].outputs[0].invoiceID;
+              }
 
-          if (wallet.credentials.token) {
-            txp.tokenAddress = wallet.credentials.token.address;
-          }
+              if (wallet.credentials.token) {
+                txp.tokenAddress = wallet.credentials.token.address;
+              }
 
-          if (wallet.credentials.multisigEthInfo) {
-            txp.multisigContractAddress =
-              wallet.credentials.multisigEthInfo.multisigContractAddress;
-          }
+              if (wallet.credentials.multisigEthInfo) {
+                txp.multisigContractAddress =
+                  wallet.credentials.multisigEthInfo.multisigContractAddress;
+              }
 
-          if (details.requiredFeeRate) {
-            const requiredFeeRate = !this.currencyProvider.isUtxoCoin(
-              wallet.coin
-            )
-              ? details.requiredFeeRate
-              : Math.ceil(details.requiredFeeRate * 1024);
-            txp.feePerKb = requiredFeeRate;
-            this.logger.debug(
-              `PayProDetails requiredFeeRate: ${
-                details.requiredFeeRate
-              }. Txp feePerKb: ${txp.feePerKb}`
-            );
-            this.logger.debug(
-              'Using merchant fee rate (for debit card):' + txp.feePerKb
-            );
-          } else {
-            txp.feeLevel = this.feeProvider.getCoinCurrentFeeLevel(wallet.coin);
-          }
+              if (details.requiredFeeRate) {
+                const requiredFeeRate = !this.currencyProvider.isUtxoCoin(
+                  wallet.coin
+                )
+                  ? details.requiredFeeRate
+                  : Math.ceil(details.requiredFeeRate * 1024);
+                txp.feePerKb = requiredFeeRate;
+                this.logger.debug(
+                  `PayProDetails requiredFeeRate: ${
+                    details.requiredFeeRate
+                  }. Txp feePerKb: ${txp.feePerKb}`
+                );
+                this.logger.debug(
+                  'Using merchant fee rate (for debit card):' + txp.feePerKb
+                );
+              } else {
+                txp.feeLevel = this.feeProvider.getCoinCurrentFeeLevel(
+                  wallet.coin
+                );
+              }
 
-          txp['origToAddress'] = txp.toAddress;
+              txp['origToAddress'] = txp.toAddress;
 
-          if (wallet.coin && wallet.coin == 'bch') {
-            txp.toAddress = this.bitcoreCash
-              .Address(txp.toAddress)
-              .toString(true);
-            txp.outputs[0].toAddress = txp.toAddress;
-          }
+              if (wallet.coin && wallet.coin == 'bch') {
+                txp.toAddress = this.bitcoreCash
+                  .Address(txp.toAddress)
+                  .toString(true);
+                txp.outputs[0].toAddress = txp.toAddress;
+              }
 
-          return this.walletProvider
-            .getAddress(this.wallet, false)
-            .then(address => {
-              txp.from = address;
-              this.walletProvider
+              return this.walletProvider
                 .createTx(wallet, txp)
                 .then(ctxp => {
                   return resolve(ctxp);
@@ -564,50 +570,64 @@ export class BitPayCardTopUpPage {
 
                 this.logger.debug(`Getting paypro details`);
 
-                this.payproProvider
-                  .getPayProDetails(payProUrl, wallet.coin)
-                  .then(details => {
-                    const payProFeeSat = !this.currencyProvider.isUtxoCoin(
-                      wallet.coin
-                    )
-                      ? details.requiredFeeRate
-                      : Math.ceil(details.requiredFeeRate * 1024);
-
-                    this.logger.debug(
-                      `getPayProDetails -> payProFeeSat: ${payProFeeSat}`
-                    );
-
-                    let transactionFee =
-                      payProFeeSat > maxAmountFeeSat
-                        ? payProFeeSat
-                        : maxAmountFeeSat;
-
-                    this.logger.debug(`transactionFee: ${transactionFee}`);
-
-                    let newAmountSat =
-                      maxAmountSat - invoiceFeeSat - transactionFee;
-
-                    if (newAmountSat <= 0) {
-                      return reject({
-                        message: this.translate.instant(
-                          'Insufficient funds for fee'
+                this.walletProvider
+                  .getAddress(wallet, false)
+                  .then(address => {
+                    this.payproProvider
+                      .getPayProDetails({
+                        paymentUrl: payProUrl,
+                        coin: wallet.coin,
+                        address
+                      })
+                      .then(details => {
+                        const payProFeeSat = !this.currencyProvider.isUtxoCoin(
+                          wallet.coin
                         )
+                          ? details.requiredFeeRate
+                          : Math.ceil(details.requiredFeeRate * 1024);
+
+                        this.logger.debug(
+                          `getPayProDetails -> payProFeeSat: ${payProFeeSat}`
+                        );
+
+                        let transactionFee =
+                          payProFeeSat > maxAmountFeeSat
+                            ? payProFeeSat
+                            : maxAmountFeeSat;
+
+                        this.logger.debug(`transactionFee: ${transactionFee}`);
+
+                        let newAmountSat =
+                          maxAmountSat - invoiceFeeSat - transactionFee;
+
+                        if (newAmountSat <= 0) {
+                          return reject({
+                            message: this.translate.instant(
+                              'Insufficient funds for fee'
+                            )
+                          });
+                        }
+
+                        this.logger.debug(
+                          `Calculating newAmountSat (newAmountSat = maxAmountSat - invoiceFeeSat - transactionFee). newAmountSat: ${newAmountSat}`
+                        );
+
+                        return resolve({
+                          amount: newAmountSat,
+                          currency: 'sat'
+                        });
+                      })
+                      .catch(err => {
+                        throw {
+                          title: this.translate.instant(
+                            'Error fetching this invoice'
+                          ),
+                          message: this.bwcErrorProvider.msg(err)
+                        };
                       });
-                    }
-
-                    this.logger.debug(
-                      `Calculating newAmountSat (newAmountSat = maxAmountSat - invoiceFeeSat - transactionFee). newAmountSat: ${newAmountSat}`
-                    );
-
-                    return resolve({ amount: newAmountSat, currency: 'sat' });
                   })
                   .catch(err => {
-                    throw {
-                      title: this.translate.instant(
-                        'Error fetching this invoice'
-                      ),
-                      message: this.bwcErrorProvider.msg(err)
-                    };
+                    return reject(err);
                   });
               })
               .catch(err => {

--- a/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
+++ b/src/pages/integrations/bitpay-card/bitpay-card-topup/bitpay-card-topup.ts
@@ -323,11 +323,14 @@ export class BitPayCardTopUpPage {
       this.walletProvider
         .getAddress(wallet, false)
         .then(address => {
+          const payload = {
+            address
+          };
           this.payproProvider
             .getPayProDetails({
               paymentUrl: payProUrl,
               coin: wallet.coin,
-              address
+              payload
             })
             .then(details => {
               const { instructions } = details;
@@ -573,11 +576,14 @@ export class BitPayCardTopUpPage {
                 this.walletProvider
                   .getAddress(wallet, false)
                   .then(address => {
+                    const payload = {
+                      address
+                    };
                     this.payproProvider
                       .getPayProDetails({
                         paymentUrl: payProUrl,
                         coin: wallet.coin,
-                        address
+                        payload
                       })
                       .then(details => {
                         const payProFeeSat = !this.currencyProvider.isUtxoCoin(

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -115,7 +115,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
     txFormatProvider: TxFormatProvider,
     walletProvider: WalletProvider,
     translate: TranslateService,
-    private payproProvider: PayproProvider,
+    payproProvider: PayproProvider,
     platformProvider: PlatformProvider,
     clipboardProvider: ClipboardProvider,
     events: Events,
@@ -152,6 +152,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
       events,
       coinbaseProvider,
       appProvider,
+      payproProvider,
       iabCardProvider
     );
     this.configWallet = this.configProvider.get().wallet;
@@ -343,7 +344,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
       err_title = this.translate.instant('Service not available');
       err_msg = this.translate.instant(
         `${
-          this.cardConfig.displayName
+        this.cardConfig.displayName
         } gift card purchases are not available at this time. Please try again later.`
       );
     } else if (errMessage) {
@@ -683,7 +684,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
     this.wallet = wallet;
     this.isERCToken = this.currencyProvider.isERCToken(this.wallet.coin);
     const email = await this.promptEmail();
-    await this.initialize(wallet, email).catch(() => {});
+    await this.initialize(wallet, email).catch(() => { });
   }
 
   public showWallets(): void {

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -344,7 +344,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
       err_title = this.translate.instant('Service not available');
       err_msg = this.translate.instant(
         `${
-        this.cardConfig.displayName
+          this.cardConfig.displayName
         } gift card purchases are not available at this time. Please try again later.`
       );
     } else if (errMessage) {
@@ -684,7 +684,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
     this.wallet = wallet;
     this.isERCToken = this.currencyProvider.isERCToken(this.wallet.coin);
     const email = await this.promptEmail();
-    await this.initialize(wallet, email).catch(() => { });
+    await this.initialize(wallet, email).catch(() => {});
   }
 
   public showWallets(): void {

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -397,8 +397,10 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
       };
     }
 
+    const address = await this.walletProvider.getAddress(wallet, false);
+
     const details = await this.payproProvider
-      .getPayProDetails(payProUrl, wallet.coin)
+      .getPayProDetails({ paymentUrl: payProUrl, coin: wallet.coin, address })
       .catch(err => {
         throw {
           title: this.translate.instant('Error fetching this invoice'),
@@ -409,6 +411,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
     const txp: Partial<TransactionProposal> = {
       coin: wallet.coin,
       amount: _.sumBy(instructions, 'amount'),
+      from: address,
       toAddress: instructions[0].toAddress,
       outputs: [],
       message,
@@ -464,19 +467,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
       txp.toAddress = this.bitcoreCash.Address(txp.toAddress).toString(true);
       txp.outputs[0].toAddress = txp.toAddress;
     }
-
-    return this.walletProvider
-      .getAddress(this.wallet, false)
-      .then(address => {
-        txp.from = address;
-        return this.walletProvider.createTx(wallet, txp);
-      })
-      .catch(err => {
-        throw {
-          title: this.translate.instant('Could not create transaction'),
-          message: this.bwcErrorProvider.msg(err)
-        };
-      });
+    return this.walletProvider.createTx(wallet, txp);
   }
 
   private async redeemGiftCard(initialCard: GiftCard) {

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -399,9 +399,11 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
     }
 
     const address = await this.walletProvider.getAddress(wallet, false);
-
+    const payload = {
+      address
+    };
     const details = await this.payproProvider
-      .getPayProDetails({ paymentUrl: payProUrl, coin: wallet.coin, address })
+      .getPayProDetails({ paymentUrl: payProUrl, coin: wallet.coin, payload })
       .catch(err => {
         throw {
           title: this.translate.instant('Error fetching this invoice'),

--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -208,9 +208,9 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
 
     this.coinbaseAccounts = this.showCoinbase
       ? this.coinbaseProvider.getAvailableAccounts(null, {
-        amount: this.amount,
-        currency: this.currency
-      })
+          amount: this.amount,
+          currency: this.currency
+        })
       : [];
 
     if (
@@ -364,7 +364,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
       err_title = this.translate.instant('Service not available');
       err_msg = this.translate.instant(
         `${
-        this.cardConfig.displayName
+          this.cardConfig.displayName
         } gift card purchases are not available at this time. Please try again later.`
       );
     } else if (errMessage) {
@@ -843,14 +843,14 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
       this.coinbaseAccount = option.accountSelected;
       const email = this.coinbaseProvider.coinbaseData.user.email;
       await this.initializeCoinbase(option.accountSelected, email).catch(
-        () => { }
+        () => {}
       );
     } else {
       this.wallet = option;
       this.coinbaseAccount = null;
       this.isERCToken = this.currencyProvider.isERCToken(this.wallet.coin);
       const email = await this.promptEmail();
-      await this.initialize(option, email).catch(() => { });
+      await this.initialize(option, email).catch(() => {});
     }
   }
 

--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -391,15 +391,18 @@ export class ConfirmPage {
     );
 
     if (this.tx.paypro) {
-      if (this.currencyProvider.isERCToken(wallet.coin)) {
-        const address = await this.walletProvider.getAddress(wallet, false);
-        this.tx.paypro = await this.payproProvider.getPayProDetails({
-          paymentUrl: this.tx.payProUrl,
-          coin: wallet.coin,
-          address,
-          disableLoader: true
-        });
-      }
+      const address = await this.walletProvider.getAddress(wallet, false);
+      const payload = {
+        address
+      };
+      this.tx.paypro = await this.payproProvider.getPayProDetails({
+        paymentUrl: this.tx.payProUrl,
+        coin: wallet.coin,
+        payload,
+        disableLoader: true
+      });
+      // Update Fees to most recent
+      this.tx.feeRate = this.tx.paypro.requiredFeeRate;
       this.paymentTimeControl(this.tx.paypro.expires);
     }
 

--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -32,6 +32,7 @@ import { ExternalLinkProvider } from '../../../providers/external-link/external-
 import { FeeProvider } from '../../../providers/fee/fee';
 import { IABCardProvider } from '../../../providers/in-app-browser/card';
 import { OnGoingProcessProvider } from '../../../providers/on-going-process/on-going-process';
+import { PayproProvider } from '../../../providers/paypro/paypro';
 import { PlatformProvider } from '../../../providers/platform/platform';
 import { PopupProvider } from '../../../providers/popup/popup';
 import { ProfileProvider } from '../../../providers/profile/profile';
@@ -129,6 +130,7 @@ export class ConfirmPage {
     protected events: Events,
     protected coinbaseProvider: CoinbaseProvider,
     protected appProvider: AppProvider,
+    protected payproProvider: PayproProvider,
     private iabCardProvider: IABCardProvider
   ) {
     this.wallet = this.profileProvider.getWallet(this.navParams.data.walletId);
@@ -371,7 +373,7 @@ export class ConfirmPage {
 
   /* sets a wallet on the UI, creates a TXPs for that wallet */
 
-  private setWallet(wallet): void {
+  private async setWallet(wallet) {
     this.wallet = wallet;
 
     // If select another wallet
@@ -388,7 +390,19 @@ export class ConfirmPage {
       this.isSpeedUpTx
     );
 
-    if (this.tx.paypro) this.paymentTimeControl(this.tx.paypro.expires);
+    if (this.tx.paypro) {
+      if (this.currencyProvider.isERCToken(wallet.coin)) {
+        const address = await this.walletProvider.getAddress(wallet, false);
+        this.tx.paypro = await this.payproProvider.getPayProDetails({
+          paymentUrl: this.tx.payProUrl,
+          coin: wallet.coin,
+          address,
+          disableLoader: true
+        });
+      }
+      this.paymentTimeControl(this.tx.paypro.expires);
+    }
+
     const exit =
       this.wallet || (this.wallets && this.wallets.length === 1) ? true : false;
     const feeOpts = this.feeProvider.getFeeOpts();

--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -315,7 +315,7 @@ export class ConfirmPage {
   private getAmountDetails() {
     this.amount = this.decimalPipe.transform(
       this.tx.amount /
-      this.currencyProvider.getPrecision(this.coin).unitToSatoshi,
+        this.currencyProvider.getPrecision(this.coin).unitToSatoshi,
       '1.2-6'
     );
   }
@@ -325,7 +325,7 @@ export class ConfirmPage {
       this.totalAmount = tx.amount + tx.txp[wallet.id].fee;
       this.totalAmountStr = this.decimalPipe.transform(
         (tx.amount + tx.txp[wallet.id].fee) /
-        this.currencyProvider.getPrecision(this.coin).unitToSatoshi,
+          this.currencyProvider.getPrecision(this.coin).unitToSatoshi,
         '1.2-6'
       );
     }
@@ -479,7 +479,7 @@ export class ConfirmPage {
       this.totalAmount = this.tx.amount - this.tx.minerFee;
       this.totalAmountStr = this.decimalPipe.transform(
         this.totalAmount /
-        this.currencyProvider.getPrecision(this.coin).unitToSatoshi,
+          this.currencyProvider.getPrecision(this.coin).unitToSatoshi,
         '1.2-6'
       );
     }
@@ -489,7 +489,7 @@ export class ConfirmPage {
     return (
       this.wallet.cachedStatus &&
       this.wallet.cachedStatus.balance.totalAmount >=
-      this.tx.amount + this.tx.feeRate &&
+        this.tx.amount + this.tx.feeRate &&
       !this.tx.spendUnconfirmed
     );
   }
@@ -606,7 +606,7 @@ export class ConfirmPage {
             const maxAllowedFee = feeRate * 5;
             this.logger.info(
               `Using Merchant Fee: ${
-              tx.feeRate
+                tx.feeRate
               } vs. referent level (5 * feeRate) ${maxAllowedFee}`
             );
             const isUtxo = this.currencyProvider.isUtxoCoin(wallet.coin);
@@ -805,9 +805,9 @@ export class ConfirmPage {
           this.tx = tx;
           this.logger.debug(
             'Confirm. TX Fully Updated for wallet:' +
-            wallet.id +
-            ' Txp:' +
-            txp.id
+              wallet.id +
+              ' Txp:' +
+              txp.id
           );
 
           this.getTotalAmountDetails(tx, wallet);

--- a/src/pages/txp-details/txp-details.ts
+++ b/src/pages/txp-details/txp-details.ts
@@ -230,12 +230,15 @@ export class TxpDetailsPage {
       this.walletProvider
         .getAddress(this.wallet, false)
         .then(address => {
+          const payload = {
+            address
+          };
           const disableLoader = true;
           this.payproProvider
             .getPayProDetails({
               paymentUrl: this.tx.payProUrl,
               coin: this.tx.coin,
-              address,
+              payload,
               disableLoader
             })
             .then(payProDetails => {

--- a/src/pages/txp-details/txp-details.ts
+++ b/src/pages/txp-details/txp-details.ts
@@ -227,19 +227,38 @@ export class TxpDetailsPage {
 
   private checkPaypro(): void {
     if (this.tx.payProUrl) {
-      const disableLoader = true;
-      this.payproProvider
-        .getPayProDetails(this.tx.payProUrl, this.tx.coin, disableLoader)
-        .then(payProDetails => {
-          this.tx.paypro = payProDetails;
-          this.paymentTimeControl(this.tx.paypro.expires);
+      this.walletProvider
+        .getAddress(this.wallet, false)
+        .then(address => {
+          const disableLoader = true;
+          this.payproProvider
+            .getPayProDetails({
+              paymentUrl: this.tx.payProUrl,
+              coin: this.tx.coin,
+              address,
+              disableLoader
+            })
+            .then(payProDetails => {
+              this.tx.paypro = payProDetails;
+              this.paymentTimeControl(this.tx.paypro.expires);
+            })
+            .catch(err => {
+              this.logger.warn(
+                'Error fetching this invoice: ',
+                this.bwcErrorProvider.msg(err)
+              );
+              this.paymentExpired = true;
+              this.showErrorInfoSheet(
+                this.bwcErrorProvider.msg(err),
+                this.translate.instant('Error fetching this invoice')
+              );
+            });
         })
         .catch(err => {
           this.logger.warn(
             'Error fetching this invoice: ',
             this.bwcErrorProvider.msg(err)
           );
-          this.paymentExpired = true;
           this.showErrorInfoSheet(
             this.bwcErrorProvider.msg(err),
             this.translate.instant('Error fetching this invoice')

--- a/src/providers/incoming-data/incoming-data.spec.ts
+++ b/src/providers/incoming-data/incoming-data.spec.ts
@@ -290,11 +290,11 @@ describe('Provider: Incoming Data Provider', () => {
           params: stateParams
         };
 
-        expect(getPayProDetailsSpy).toHaveBeenCalledWith(
-          element.payProUrl,
-          element.paymentOptions[2].currency.toLowerCase(),
-          true
-        );
+        expect(getPayProDetailsSpy).toHaveBeenCalledWith({
+          paymentUrl: element.payProUrl,
+          coin: element.paymentOptions[2].currency.toLowerCase(),
+          disableLoader: true
+        });
         expect(eventsSpy).toHaveBeenCalledWith('IncomingDataRedir', nextView);
       });
     }));

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -1186,7 +1186,7 @@ export class IncomingDataProvider {
     disableLoader?: boolean
   ): void {
     this.payproProvider
-      .getPayProDetails(url, coin, disableLoader)
+      .getPayProDetails({ paymentUrl: url, coin, disableLoader })
       .then(details => {
         this.onGoingProcessProvider.clear();
         this.handlePayPro(details, payProOptions, url, coin);

--- a/src/providers/paypro/paypro.spec.ts
+++ b/src/providers/paypro/paypro.spec.ts
@@ -38,7 +38,10 @@ describe('PayProProvider', () => {
       });
 
       payproProvider
-        .getPayProDetails('https://bitpay.com/i/5GREtmntcTvB9aejVDhVdm', 'btc')
+        .getPayProDetails({
+          paymentUrl: 'https://bitpay.com/i/5GREtmntcTvB9aejVDhVdm',
+          coin: 'btc'
+        })
         .then(paypro => {
           expect(paypro).toEqual(defaultPayPro);
         })
@@ -54,7 +57,10 @@ describe('PayProProvider', () => {
       });
 
       payproProvider
-        .getPayProDetails('https://bitpay.com/i/5GREtmntcTvB9aejVDhVdm', 'btc')
+        .getPayProDetails({
+          paymentUrl: 'https://bitpay.com/i/5GREtmntcTvB9aejVDhVdm',
+          coin: 'btc'
+        })
         .then(paypro => {
           expect(paypro).toBeUndefined();
         })

--- a/src/providers/paypro/paypro.ts
+++ b/src/providers/paypro/paypro.ts
@@ -48,11 +48,11 @@ export class PayproProvider {
   public async getPayProDetails(params: {
     paymentUrl;
     coin;
-    address?: string;
+    payload?: { address?: string };
     disableLoader?: boolean;
     attempt?: number;
   }): Promise<any> {
-    let { paymentUrl, coin, address, disableLoader, attempt = 1 } = params;
+    let { paymentUrl, coin, payload, disableLoader, attempt = 1 } = params;
     this.logger.info('PayPro Details: try... ' + attempt);
     const bwc = this.bwcProvider.getPayProV2();
     const chain = this.currencyProvider.getChain(coin).toUpperCase();
@@ -60,7 +60,7 @@ export class PayproProvider {
       paymentUrl,
       chain,
       currency: coin.toUpperCase(),
-      address
+      payload
     };
     if (!disableLoader) {
       this.onGoingProcessProvider.set('fetchingPayPro');
@@ -75,7 +75,7 @@ export class PayproProvider {
           return this.getPayProDetails({
             paymentUrl,
             coin,
-            address,
+            payload,
             disableLoader,
             attempt: ++attempt
           });

--- a/src/providers/paypro/paypro.ts
+++ b/src/providers/paypro/paypro.ts
@@ -45,19 +45,22 @@ export class PayproProvider {
     return payOpts;
   }
 
-  public async getPayProDetails(
-    paymentUrl,
-    coin,
-    disableLoader?: boolean,
-    attempt: number = 1
-  ): Promise<any> {
+  public async getPayProDetails(params: {
+    paymentUrl;
+    coin;
+    address?: string;
+    disableLoader?: boolean;
+    attempt?: number;
+  }): Promise<any> {
+    let { paymentUrl, coin, address, disableLoader, attempt = 1 } = params;
     this.logger.info('PayPro Details: try... ' + attempt);
     const bwc = this.bwcProvider.getPayProV2();
     const chain = this.currencyProvider.getChain(coin).toUpperCase();
     const options: any = {
       paymentUrl,
       chain,
-      currency: coin.toUpperCase()
+      currency: coin.toUpperCase(),
+      address
     };
     if (!disableLoader) {
       this.onGoingProcessProvider.set('fetchingPayPro');
@@ -69,12 +72,13 @@ export class PayproProvider {
         this.logger.error('PayPro Details: ERROR', JSON.stringify(err));
         if (attempt <= 5) {
           await new Promise(resolve => setTimeout(resolve, 3000 * attempt));
-          return this.getPayProDetails(
+          return this.getPayProDetails({
             paymentUrl,
             coin,
+            address,
             disableLoader,
-            ++attempt
-          );
+            attempt: ++attempt
+          });
         } else {
           if (!disableLoader) this.onGoingProcessProvider.clear();
           throw err;


### PR DESCRIPTION
Add address param to `getPaymentDetails` for ERC20 allowance check in paypro.

Change parameters to object for easy destructuring and adding more optional params in the future.

```
getPayProDetails(params: {
    paymentUrl: string;
    coin: Coin;
    disableLoader?: boolean;
    address?: string;
    attempt: number = 1
  })
```

Related MR:

https://git.b-pay.net/bitpay/bitpay/-/merge_requests/5982

Bitcore:

https://github.com/bitpay/bitcore/pull/2940