### PR TITLE
Disable SEPA bank transfer payment method

### DIFF
--- a/src/providers/buy-crypto/buy-crypto.ts
+++ b/src/providers/buy-crypto/buy-crypto.ts
@@ -49,7 +49,7 @@ export class BuyCryptoProvider {
           simplex: true, // EU Only
           wyre: false
         },
-        enabled: true
+        enabled: false // TODO: Enable again once successfully tested from the simplex website
       },
       creditCard: {
         label: this.translate.instant('Credit Card'),


### PR DESCRIPTION
This feature will be disabled until Simplex ensures a stable version from its website