### PR TITLE
fix(bp-card-intro): release camera resources after initializing scanner

### DIFF
--- a/src/pages/integrations/bitpay-card/bitpay-card-intro/bitpay-card-intro.ts
+++ b/src/pages/integrations/bitpay-card/bitpay-card-intro/bitpay-card-intro.ts
@@ -111,8 +111,6 @@ export class BitPayCardIntroPage {
 
     if (!this.scannerHasPermission) {
       this.authorizeCamera();
-    } else {
-      this.activateCamera();
     }
   }
 
@@ -127,17 +125,10 @@ export class BitPayCardIntroPage {
   }
 
   private authorizeCamera(): void {
-    this.scanProvider.initialize().then(() => {
-      this.activateCamera();
-    });
-  }
-
-  private activateCamera(): void {
-    this.scanProvider.activate().then(() => {
-      this.updateCapabilities();
-      // resume preview if paused
-      this.scanProvider.resumePreview();
-    });
+    this.scanProvider
+      .initialize() // prompt for authorization by initializing scanner
+      .then(() => this.scanProvider.pausePreview()) // release camera resources from scanner
+      .then(() => this.updateCapabilities()); // update component state
   }
 
   public openExchangeRates() {


### PR DESCRIPTION
This PR pauses the scanner preview after initializing it from the card intro. The purpose of calling the scanner initialization is solely to invoke a camera permission request, so it should be safe to pause it immediately after. On Android, the selfie camera was not available in the InAppBrowser until the scanner is paused. 

Tested against Pixel 3 XL / Android 11.